### PR TITLE
Close transfer preview modal and reset form after success 

### DIFF
--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2538,6 +2538,26 @@ html {
   margin-bottom: 1.25rem;
 }
 
+.-mx-1 {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.-mx-1\.5 {
+  margin-left: -0.375rem;
+  margin-right: -0.375rem;
+}
+
+.-my-1 {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+}
+
+.-my-1\.5 {
+  margin-top: -0.375rem;
+  margin-bottom: -0.375rem;
+}
+
 .mb-1 {
   margin-bottom: 0.25rem;
 }
@@ -2590,12 +2610,24 @@ html {
   margin-top: 2rem;
 }
 
+.ms-3 {
+  margin-inline-start: 0.75rem;
+}
+
+.ms-auto {
+  margin-inline-start: auto;
+}
+
 .block {
   display: block;
 }
 
 .flex {
   display: flex;
+}
+
+.inline-flex {
+  display: inline-flex;
 }
 
 .table {
@@ -2612,6 +2644,14 @@ html {
 
 .h-4 {
   height: 1rem;
+}
+
+.h-3 {
+  height: 0.75rem;
+}
+
+.h-8 {
+  height: 2rem;
 }
 
 .max-h-full {
@@ -2646,6 +2686,14 @@ html {
   width: 100%;
 }
 
+.w-3 {
+  width: 0.75rem;
+}
+
+.w-8 {
+  width: 2rem;
+}
+
 .max-w-3xl {
   max-width: 48rem;
 }
@@ -2656,6 +2704,10 @@ html {
 
 .max-w-sm {
   max-width: 24rem;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
 }
 
 .transform {
@@ -2840,6 +2892,11 @@ html {
   background-color: rgb(185 28 28 / var(--tw-bg-opacity));
 }
 
+.bg-blue-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 246 255 / var(--tw-bg-opacity));
+}
+
 .p-1 {
   padding: 0.25rem;
 }
@@ -2858,6 +2915,10 @@ html {
 
 .p-5 {
   padding: 1.25rem;
+}
+
+.p-1\.5 {
+  padding: 0.375rem;
 }
 
 .px-1 {
@@ -3060,6 +3121,20 @@ html {
   color: rgb(161 98 7 / var(--tw-text-opacity));
 }
 
+.text-blue-500 {
+  --tw-text-opacity: 1;
+  color: rgb(59 130 246 / var(--tw-text-opacity));
+}
+
+.text-blue-800 {
+  --tw-text-opacity: 1;
+  color: rgb(30 64 175 / var(--tw-text-opacity));
+}
+
+.underline {
+  text-decoration-line: underline;
+}
+
 .shadow {
   --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
@@ -3239,6 +3314,11 @@ body main {
   background-color: rgb(185 28 28 / 0.8);
 }
 
+.hover\:bg-blue-200:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(191 219 254 / var(--tw-bg-opacity));
+}
+
 .hover\:text-black:hover {
   --tw-text-opacity: 1;
   color: rgb(0 0 0 / var(--tw-text-opacity));
@@ -3246,6 +3326,10 @@ body main {
 
 .hover\:underline:hover {
   text-decoration-line: underline;
+}
+
+.hover\:no-underline:hover {
+  text-decoration-line: none;
 }
 
 .focus\:border-blue-500:focus {
@@ -3272,6 +3356,11 @@ body main {
 .focus\:ring-gray-200:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(229 231 235 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-blue-400:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity));
 }
 
 @media (min-width: 768px) {
@@ -3393,5 +3482,22 @@ body main {
 @media (min-width: 1280px) {
   .xl\:w-1\/4 {
     width: 25%;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .dark\:bg-gray-800 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+  }
+
+  .dark\:text-blue-400 {
+    --tw-text-opacity: 1;
+    color: rgb(96 165 250 / var(--tw-text-opacity));
+  }
+
+  .dark\:hover\:bg-gray-700:hover {
+    --tw-bg-opacity: 1;
+    background-color: rgb(55 65 81 / var(--tw-bg-opacity));
   }
 }

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2538,26 +2538,6 @@ html {
   margin-bottom: 1.25rem;
 }
 
-.-mx-1 {
-  margin-left: -0.25rem;
-  margin-right: -0.25rem;
-}
-
-.-mx-1\.5 {
-  margin-left: -0.375rem;
-  margin-right: -0.375rem;
-}
-
-.-my-1 {
-  margin-top: -0.25rem;
-  margin-bottom: -0.25rem;
-}
-
-.-my-1\.5 {
-  margin-top: -0.375rem;
-  margin-bottom: -0.375rem;
-}
-
 .mb-1 {
   margin-bottom: 0.25rem;
 }
@@ -2610,24 +2590,12 @@ html {
   margin-top: 2rem;
 }
 
-.ms-3 {
-  margin-inline-start: 0.75rem;
-}
-
-.ms-auto {
-  margin-inline-start: auto;
-}
-
 .block {
   display: block;
 }
 
 .flex {
   display: flex;
-}
-
-.inline-flex {
-  display: inline-flex;
 }
 
 .table {
@@ -2644,14 +2612,6 @@ html {
 
 .h-4 {
   height: 1rem;
-}
-
-.h-3 {
-  height: 0.75rem;
-}
-
-.h-8 {
-  height: 2rem;
 }
 
 .max-h-full {
@@ -2686,14 +2646,6 @@ html {
   width: 100%;
 }
 
-.w-3 {
-  width: 0.75rem;
-}
-
-.w-8 {
-  width: 2rem;
-}
-
 .max-w-3xl {
   max-width: 48rem;
 }
@@ -2704,10 +2656,6 @@ html {
 
 .max-w-sm {
   max-width: 24rem;
-}
-
-.flex-shrink-0 {
-  flex-shrink: 0;
 }
 
 .transform {
@@ -2892,11 +2840,6 @@ html {
   background-color: rgb(185 28 28 / var(--tw-bg-opacity));
 }
 
-.bg-blue-50 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 246 255 / var(--tw-bg-opacity));
-}
-
 .p-1 {
   padding: 0.25rem;
 }
@@ -2915,10 +2858,6 @@ html {
 
 .p-5 {
   padding: 1.25rem;
-}
-
-.p-1\.5 {
-  padding: 0.375rem;
 }
 
 .px-1 {
@@ -3121,20 +3060,6 @@ html {
   color: rgb(161 98 7 / var(--tw-text-opacity));
 }
 
-.text-blue-500 {
-  --tw-text-opacity: 1;
-  color: rgb(59 130 246 / var(--tw-text-opacity));
-}
-
-.text-blue-800 {
-  --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity));
-}
-
-.underline {
-  text-decoration-line: underline;
-}
-
 .shadow {
   --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
@@ -3314,11 +3239,6 @@ body main {
   background-color: rgb(185 28 28 / 0.8);
 }
 
-.hover\:bg-blue-200:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(191 219 254 / var(--tw-bg-opacity));
-}
-
 .hover\:text-black:hover {
   --tw-text-opacity: 1;
   color: rgb(0 0 0 / var(--tw-text-opacity));
@@ -3326,10 +3246,6 @@ body main {
 
 .hover\:underline:hover {
   text-decoration-line: underline;
-}
-
-.hover\:no-underline:hover {
-  text-decoration-line: none;
 }
 
 .focus\:border-blue-500:focus {
@@ -3356,11 +3272,6 @@ body main {
 .focus\:ring-gray-200:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(229 231 235 / var(--tw-ring-opacity));
-}
-
-.focus\:ring-blue-400:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity));
 }
 
 @media (min-width: 768px) {
@@ -3482,22 +3393,5 @@ body main {
 @media (min-width: 1280px) {
   .xl\:w-1\/4 {
     width: 25%;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .dark\:bg-gray-800 {
-    --tw-bg-opacity: 1;
-    background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-  }
-
-  .dark\:text-blue-400 {
-    --tw-text-opacity: 1;
-    color: rgb(96 165 250 / var(--tw-text-opacity));
-  }
-
-  .dark\:hover\:bg-gray-700:hover {
-    --tw-bg-opacity: 1;
-    background-color: rgb(55 65 81 / var(--tw-bg-opacity));
   }
 }

--- a/pkg/web/templates/layouts/base.html
+++ b/pkg/web/templates/layouts/base.html
@@ -15,6 +15,7 @@
 
   <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/htmx.org@1.9.11/dist/ext/json-enc.js"></script>
+  <script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
   <script src="/static/js/main.js"></script>
   {{ block "appcode" . }}{{ end }}
 </body>

--- a/pkg/web/templates/partials/transaction/transaction_preview.html
+++ b/pkg/web/templates/partials/transaction/transaction_preview.html
@@ -24,11 +24,7 @@
           >
           <input type="hidden" id="travel_address" name="travel_address" value="{{ .Dump }}" />
           <div class="flex flex-row md:w-1/3 gap-x-2 md:gap-4 w-full">
-            <button 
-              type="submit" 
-              class="p-1 rounded bg-green-700 font-semibold text-white md:p-2 hover:bg-green-700/80">
-              Send
-            </button>
+            <button type="submit" class="p-1 rounded bg-green-700 font-semibold text-white md:p-2 hover:bg-green-700/80">Send</button>
             <button type="button" onclick="preview_envelope.close()" class="p-1 rounded bg-[#55ACD8] font-semibold text-white md:p-2 hover:bg-[#55ACD8]/80">Edit</button>
             <button type="button" onclick="preview_envelope.close()" class="p-1 rounded bg-red-700 font-semibold text-white md:p-2 hover:bg-red-700/80">Cancel</button>
           </div>

--- a/pkg/web/templates/partials/transaction/transaction_preview.html
+++ b/pkg/web/templates/partials/transaction/transaction_preview.html
@@ -9,10 +9,25 @@
           </h1>
         </div>
         <!-- TODO: Make buttons same width -->
-        <form hx-post="/v1/transactions/send" hx-ext="json-enc" method="post">
+        <form 
+          _="on htmx:afterRequest
+              if event.detail.successful
+                remove @open from #preview_envelope
+                then reset() the #secure-envelope-form
+                then remove .ss-single from <div.ss-values/>" 
+          hx-post="/v1/transactions/send" 
+          hx-target="#secure-envelope-form" 
+          hx-swap="none" 
+          hx-ext="json-enc" 
+          method="post"
+          >
           <input type="hidden" id="travel_address" name="travel_address" value="{{ .Dump }}" />
           <div class="flex flex-row md:w-1/3 gap-x-2 md:gap-4 w-full">
-            <button type="submit" class="p-1 rounded bg-green-700 font-semibold text-white md:p-2 hover:bg-green-700/80">Send</button>
+            <button 
+              type="submit" 
+              class="p-1 rounded bg-green-700 font-semibold text-white md:p-2 hover:bg-green-700/80">
+              Send
+            </button>
             <button type="button" onclick="preview_envelope.close()" class="p-1 rounded bg-[#55ACD8] font-semibold text-white md:p-2 hover:bg-[#55ACD8]/80">Edit</button>
             <button type="button" onclick="preview_envelope.close()" class="p-1 rounded bg-red-700 font-semibold text-white md:p-2 hover:bg-red-700/80">Cancel</button>
           </div>

--- a/pkg/web/templates/partials/transaction/transaction_preview.html
+++ b/pkg/web/templates/partials/transaction/transaction_preview.html
@@ -14,7 +14,8 @@
               if event.detail.successful
                 remove @open from #preview_envelope
                 then reset() the #secure-envelope-form
-                then remove .ss-single from <div.ss-values/>" 
+                then reload() the location of the window
+                then go to top of the body" 
           hx-post="/v1/transactions/send" 
           hx-target="#secure-envelope-form" 
           hx-swap="none" 


### PR DESCRIPTION
### Scope of changes

Add hyperscript to close the transfer preview modal after a success response. It is also used to reset the form to ensure previous values are no longer included.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/26812356?key=30e32977a1a0daba05e8185da761046d

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


