### PR TITLE
Increase add account modal width, reduce trash icon size

### DIFF
--- a/pkg/web/static/js/customerAccounts.js
+++ b/pkg/web/static/js/customerAccounts.js
@@ -40,16 +40,15 @@ document.body.addEventListener("htmx:configRequest", (e) => {
 });
 
 addWalletBttn?.addEventListener('click', () => {
-  const labelCount = walletDiv?.children.length + 1
   const walletCount = walletDiv?.children.length * 1
   walletDiv?.insertAdjacentHTML('beforeend', `
   <div class="grid gap-6 my-4 md:grid-cols-2 crypto-wallets">
     <div>
-      <label for="crypto_address_${walletCount}" class="label-style">Wallet Address ${labelCount}</label>
+      <label for="crypto_address_${walletCount}" class="label-style">Wallet Address</label>
       <input type="text" id="crypto_address_${walletCount}" name="crypto_address_${walletCount}" class="input-style" />
     </div>
     <div>
-      <label for="network_${walletCount}" class="label-style">Network ${labelCount}</label>
+      <label for="network_${walletCount}" class="label-style">Network</label>
       <div class="flex items-center gap-x-1">
         <select id="network_${walletCount}" name="network_${walletCount}"></select>
         <button type="button" onclick="this.parentNode.parentNode.parentNode.remove()" class="tooltip tooltip-left" data-tip="Delete wallet">

--- a/pkg/web/static/js/customerAccounts.js
+++ b/pkg/web/static/js/customerAccounts.js
@@ -31,6 +31,9 @@ document.body.addEventListener("htmx:configRequest", (e) => {
       }
     }
 
+    // Remove any empty objects from the crypto_addresses array.
+    data.crypto_addresses = data.crypto_addresses.filter((obj) => Object.keys(obj).length > 0)
+
     // Modify the outgoing request with the new data
     e.detail.parameters = data;
   }

--- a/pkg/web/static/js/customerAccounts.js
+++ b/pkg/web/static/js/customerAccounts.js
@@ -49,8 +49,8 @@ addWalletBttn?.addEventListener('click', () => {
       <label for="network_${walletCount}" class="label-style">Network ${labelCount}</label>
       <div class="flex items-center gap-x-1">
         <select id="network_${walletCount}" name="network_${walletCount}"></select>
-        <button type="button" onclick="this.parentNode.parentNode.parentNode.remove()">
-          <i class="fa-solid fa-trash"><span class="sr-only">Delete wallet</span></i>
+        <button type="button" onclick="this.parentNode.parentNode.parentNode.remove()" class="tooltip tooltip-left" data-tip="Delete wallet">
+          <i class="fa-solid fa-trash text-xs"><span class="sr-only">Delete wallet</span></i>
         </button>
       </div>
     </div>

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2201,14 +2201,6 @@ html {
   bottom: var(--tooltip-offset);
 }
 
-.tooltip-bottom:before {
-  transform: translateX(-50%);
-  top: var(--tooltip-offset);
-  left: 50%;
-  right: auto;
-  bottom: auto;
-}
-
 .tooltip-left:before {
   transform: translateY(-50%);
   top: 50%;
@@ -2390,15 +2382,6 @@ html {
   bottom: var(--tooltip-tail-offset);
 }
 
-.tooltip-bottom:after {
-  transform: translateX(-50%);
-  border-color: transparent transparent var(--tooltip-color) transparent;
-  top: var(--tooltip-tail-offset);
-  left: 50%;
-  right: auto;
-  bottom: auto;
-}
-
 .tooltip-left:after {
   transform: translateY(-50%);
   border-color: transparent transparent transparent var(--tooltip-color);
@@ -2511,6 +2494,10 @@ html {
   margin-inline-start: 0.5rem;
 }
 
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
 .mt-2 {
   margin-top: 0.5rem;
 }
@@ -2579,6 +2566,10 @@ html {
   width: 100%;
 }
 
+.max-w-2xl {
+  max-width: 42rem;
+}
+
 .max-w-3xl {
   max-width: 48rem;
 }
@@ -2589,19 +2580,6 @@ html {
 
 .max-w-sm {
   max-width: 24rem;
-}
-
-.max-w-fit {
-  max-width: -moz-fit-content;
-  max-width: fit-content;
-}
-
-.max-w-full {
-  max-width: 100%;
-}
-
-.max-w-2xl {
-  max-width: 42rem;
 }
 
 .transform {

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2201,6 +2201,22 @@ html {
   bottom: var(--tooltip-offset);
 }
 
+.tooltip-bottom:before {
+  transform: translateX(-50%);
+  top: var(--tooltip-offset);
+  left: 50%;
+  right: auto;
+  bottom: auto;
+}
+
+.tooltip-left:before {
+  transform: translateY(-50%);
+  top: 50%;
+  left: auto;
+  right: var(--tooltip-offset);
+  bottom: auto;
+}
+
 .tooltip-right:before {
   transform: translateY(-50%);
   top: 50%;
@@ -2372,6 +2388,24 @@ html {
   left: 50%;
   right: auto;
   bottom: var(--tooltip-tail-offset);
+}
+
+.tooltip-bottom:after {
+  transform: translateX(-50%);
+  border-color: transparent transparent var(--tooltip-color) transparent;
+  top: var(--tooltip-tail-offset);
+  left: 50%;
+  right: auto;
+  bottom: auto;
+}
+
+.tooltip-left:after {
+  transform: translateY(-50%);
+  border-color: transparent transparent transparent var(--tooltip-color);
+  top: 50%;
+  left: auto;
+  right: calc(var(--tooltip-tail-offset) + 0.0625rem);
+  bottom: auto;
 }
 
 .tooltip-right:after {
@@ -2551,6 +2585,19 @@ html {
 
 .max-w-sm {
   max-width: 24rem;
+}
+
+.max-w-fit {
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.max-w-full {
+  max-width: 100%;
+}
+
+.max-w-2xl {
+  max-width: 42rem;
 }
 
 .transform {
@@ -2882,6 +2929,11 @@ html {
 .text-xl {
   font-size: 1.25rem;
   line-height: 1.75rem;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
 }
 
 .font-black {

--- a/pkg/web/templates/accounts.html
+++ b/pkg/web/templates/accounts.html
@@ -43,11 +43,11 @@
           <div id="crypto-wallets">
             <div class="grid gap-6 my-4 md:grid-cols-2 crypto-wallets">
               <div>
-                <label for="crypto_address_0" class="label-style">Wallet Address 1</label>
+                <label for="crypto_address_0" class="label-style">Wallet Address</label>
                 <input type="text" id="crypto_address_0" name="crypto_address_0" class="input-style" />
               </div>
               <div>
-                <label for="networks" class="label-style">Network 1</label>
+                <label for="networks" class="label-style">Network</label>
                 <div class="flex items-center gap-x-1">
                   <select id="networks" name="network_0"></select>
                   <button type="button" onclick="this.parentNode.parentNode.parentNode.remove()" class="tooltip tooltip-left" data-tip="Delete wallet">

--- a/pkg/web/templates/accounts.html
+++ b/pkg/web/templates/accounts.html
@@ -17,7 +17,7 @@
 
   <!-- New Customer Account Modal -->
   <dialog id="new_acct_modal" class="modal">
-    <div class="modal-box">
+    <div class="modal-box max-w-2xl">
       <div class="flex justify-between items-center">
         <h1 class="font-bold text-xl">Add New Customer Account</h1>
         <button onclick="new_acct_modal.close()" class="btn btn-sm btn-circle btn-ghost">
@@ -25,52 +25,57 @@
           <span class="sr-only">Close modal</span>
         </button>
       </div>
-    <p class="py-4">Add new customer account details.</p>
-    <div class="">
-      <form id="new-acct-form" hx-post="/v1/accounts" hx-ext="json-enc" hx-target="#accounts" hx-swap-oob="outerHTML:#accounts" method="post">
-        <div class="mb-4">
-          <label for="first_name" class="label-style">First or Given Name</label>
-          <input type="text" id="first_name" name="first_name" class="input-style" />
-        </div>
-        <div class="mb-4">
-          <label for="last_name" class="label-style">Last or Family Name</label>
-          <input type="text" id="last_name" name="last_name" class="input-style" />
-        </div>
-        <div class="mb-4">
-          <label for="customer_id" class="label-style">Customer Account ID (optional)</label>
-          <input type="text" id="customer_id" name="customer_id" class="input-style" />
-        </div>
-        <div id="crypto-wallets">
-          <div class="grid gap-6 my-4 md:grid-cols-2 crypto-wallets">
-            <div>
-              <label for="crypto_address_0" class="label-style">Wallet Address 1</label>
-              <input type="text" id="crypto_address_0" name="crypto_address_0" class="input-style" />
-            </div>
-            <div>
-              <label for="networks" class="label-style">Network 1</label>
-              <select id="networks" name="network_0"></select>
+      <p class="py-4">Add new customer account details.</p>
+      <div class="">
+        <form id="new-acct-form" hx-post="/v1/accounts" hx-ext="json-enc" hx-target="#accounts" hx-swap-oob="outerHTML:#accounts" method="post">
+          <div class="mb-4">
+            <label for="first_name" class="label-style">First or Given Name</label>
+            <input type="text" id="first_name" name="first_name" class="input-style" />
+          </div>
+          <div class="mb-4">
+            <label for="last_name" class="label-style">Last or Family Name</label>
+            <input type="text" id="last_name" name="last_name" class="input-style" />
+          </div>
+          <div class="mb-4">
+            <label for="customer_id" class="label-style">Customer Account ID (optional)</label>
+            <input type="text" id="customer_id" name="customer_id" class="input-style" />
+          </div>
+          <div id="crypto-wallets">
+            <div class="grid gap-6 my-4 md:grid-cols-2 crypto-wallets">
+              <div>
+                <label for="crypto_address_0" class="label-style">Wallet Address 1</label>
+                <input type="text" id="crypto_address_0" name="crypto_address_0" class="input-style" />
+              </div>
+              <div>
+                <label for="networks" class="label-style">Network 1</label>
+                <div class="flex items-center gap-x-1">
+                  <select id="networks" name="network_0"></select>
+                  <button type="button" onclick="this.parentNode.parentNode.parentNode.remove()" class="tooltip tooltip-left" data-tip="Delete wallet">
+                    <i class="fa-solid fa-trash text-xs"><span class="sr-only">Delete wallet</span></i>
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="mb-4">
-          <button type="button" id="add-wallet-bttn" class="text-blue-600">+ Additional Wallets</button>
-        </div>
-        <div class="mb-4">
-          <label for="tag" class="label-style">Notes</label>
-          <textarea id="tag" name="tag" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500"></textarea>
-        </div>
-        <div class="flex justify-center">
-          <button id="acct-submit-bttn" class="w-44 btn bg-[#55ACD8] font-semibold text-lg text-white hover:bg-[#55ACD8]/90">Register</button>
-        </div>
-      </form>
+          <div class="mb-4">
+            <button type="button" id="add-wallet-bttn" class="text-blue-600">+ Additional Wallets</button>
+          </div>
+          <div class="mb-4">
+            <label for="tag" class="label-style">Notes</label>
+            <textarea id="tag" name="tag" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500"></textarea>
+          </div>
+          <div class="flex justify-center">
+            <button id="acct-submit-bttn" class="w-44 btn bg-[#55ACD8] font-semibold text-lg text-white hover:bg-[#55ACD8]/90">Register</button>
+          </div>
+        </form>
       </div>
     </div>
     <div id="network-content"></div>
   </dialog>
-  </section>
+</section>
 
-  <!-- Target for view and edit modals -->
-  <dialog id="acct_modal" class="modal"></dialog>
+<!-- Target for view and edit modals -->
+<dialog id="acct_modal" class="modal"></dialog>
 
 {{ end }}
 

--- a/pkg/web/templates/partials/account/account_detail.html
+++ b/pkg/web/templates/partials/account/account_detail.html
@@ -32,7 +32,7 @@
       </div>
       <div>
         <dd class="break-words">{{ .CryptoAddress }}<dd>
-        <dd class="mt-3 text-sm break-words">{{ .TravelAddress }}</dd>
+        <dd class="mt-1 text-sm text-gray-600 break-words">{{ .TravelAddress }}</dd>
       </div>
     </div>
   </dl>


### PR DESCRIPTION
### Scope of changes

- Update add account modal by increasing the width and decreasing size of the trash icon modal next to network.
- Remove empty objects from `crypto_addresses`.
- Add tooltip to trash icon.
- Remove number from Crypto Address and Network labels. (This was done after the acceptance criteria was created.)
- Change travel address text color in account detail view to match transactions table.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/image/47625026?key=4112a318020763ee150844b61f7c0206

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


