### PR TITLE
Make validation errors more readable

### DIFF
--- a/pkg/web/api/v1/api.go
+++ b/pkg/web/api/v1/api.go
@@ -60,9 +60,10 @@ type Client interface {
 
 // Reply contains standard fields that are used for generic API responses and errors.
 type Reply struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
-	Version string `json:"version,omitempty"`
+	Success     bool        `json:"success"`
+	Error       string      `json:"error,omitempty"`
+	Version     string      `json:"version,omitempty"`
+	ErrorDetail ErrorDetail `json:"errors,omitempty"`
 }
 
 // Returned on status requests.


### PR DESCRIPTION
### Scope of changes

This PR shortens the `ValidationErrors` message so toasts don't get crazy long:

![Screenshot 2024-04-23 at 09 50 35](https://github.com/trisacrypto/envoy/assets/745966/ca0468e3-f822-447b-882a-35a780d9e664)

The API response is as follows: (note that this can be used to add field-specific errors in the html template as well)

```json
{
  "success": false,
  "error": "5 validation errors occurred",
  "errors": [
    {
      "field": "protocol",
      "error": "missing protocol: this field is required"
    },
    {
      "field": "common_name",
      "error": "missing common_name: this field is required"
    },
    {
      "field": "endpoint",
      "error": "missing endpoint: this field is required"
    },
    {
      "field": "name",
      "error": "missing name: this field is required"
    },
    {
      "field": "country",
      "error": "missing country: this field is required"
    }
  ]
}
```

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Can you use this new data structure to more easily parse the response in html templates? Is the error message sufficient? I did try this out on the UI and it closed the modal and showed the toast. 

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


