### PR TITLE
Sc 25153

### DIFF
--- a/pkg/store/sqlite/transactions.go
+++ b/pkg/store/sqlite/transactions.go
@@ -131,6 +131,9 @@ func (s *Store) UpdateTransaction(ctx context.Context, t *models.Transaction) (e
 	// Update modified timestamp (in place).
 	t.Modified = time.Now()
 
+	// Update last update timestamp.
+	t.LastUpdate = sql.NullTime{Time: time.Now(), Valid: true}
+
 	// Execute the update into the database
 	var result sql.Result
 	if result, err = tx.Exec(updateTransactionSQL, t.Params()...); err != nil {

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -19,7 +19,7 @@
       {{ if .Transactions }}
       {{ range .Transactions }}
       <tr class="text-center">
-        <td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
           {{ if eq .Source "local" }}
           <div class="tooltip tooltip-right" data-tip="Outgoing transaction from local VASP">
             <button>
@@ -40,46 +40,46 @@
         </td>
         {{ if .Status }}
           {{ if eq .Status "draft" }}
-          <td>
+          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/draftStatusIcon.svg" alt="" />
               <span class="text-gray-500">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "pending" }}
-          <td>
+          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/pendingStatusIcon.svg" alt="" />
               <span class="text-yellow-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "action required" }}
-          <td>
+          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/actionStatusIcon.svg" alt="" />
               <span class="text-blue-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "completed" }}
-          <td>
+          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/completeStatusIcon.svg" alt="" />
               <span class="text-green-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "archived" }}
-          <td>
+          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/archiveStatusIcon.svg" alt="" />
               <span class="text-gray-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else }}
-          <td>&mdash;</td>
+          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">&mdash;</td>
           {{ end }}
         {{ end }}
-        <td>{{ .Counterparty }}</td>
-        <td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">{{ .Counterparty }}</td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
           <div>
             <ul>
               <li>{{ .Originator }}</li>
@@ -91,7 +91,7 @@
             </ul>
           </div>
         </td>
-        <td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">
           <div>
             <ul>
               <li>{{ .Beneficiary }}</li>
@@ -103,22 +103,21 @@
             </ul>
           </div>
         </td>
-        <td>{{ .VirtualAsset }}</td>
-        <td>{{ .Amount }}</td>
-        <td>{{ .EnvelopeCount }}</td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">{{ .VirtualAsset }}</td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">{{ .Amount }}</td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">{{ .EnvelopeCount }}</td>
         {{ $created := .Created.Format "January 2, 2006 15:04:05" }}
-        <td>{{ $created }}</td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">{{ $created }}</td>
         {{ if .LastUpdate.IsZero  }}
-        <td>&mdash;</td>
+        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">&mdash;</td>
         {{ else }}
         {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 15:04:05" }}
-        <td class="trans-last-update">{{ $lastUpdate }}</td>
+        <td class="cursor-pointer trans-last-update" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal">{{ $lastUpdate }}</td>
         {{ end }}
         <td>
           <div class="dropdown">
             <div tabindex="0" role="button" class="btn btn-ghost fobt-bold text-xl">&hellip;</div>
             <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-[#2F4858] font-semibold text-white rounded-box">
-              <li><a onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">View</a></li>
               {{ if eq .Source "remote" }}
               <li><a>Accept</a></li>
               <li><a>Reject</a></li>

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -19,7 +19,7 @@
       {{ if .Transactions }}
       {{ range .Transactions }}
       <tr class="text-center">
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+        <td>
           {{ if eq .Source "local" }}
           <div class="tooltip tooltip-right" data-tip="Outgoing transaction from local VASP">
             <button>
@@ -40,46 +40,46 @@
         </td>
         {{ if .Status }}
           {{ if eq .Status "draft" }}
-          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+          <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/draftStatusIcon.svg" alt="" />
               <span class="text-gray-500">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "pending" }}
-          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+          <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/pendingStatusIcon.svg" alt="" />
               <span class="text-yellow-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "action required" }}
-          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+          <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/actionStatusIcon.svg" alt="" />
               <span class="text-blue-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "completed" }}
-          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+          <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/completeStatusIcon.svg" alt="" />
               <span class="text-green-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else if eq .Status "archived" }}
-          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+          <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/archiveStatusIcon.svg" alt="" />
               <span class="text-gray-700">{{ .Status }}</span>
             </div>
           </td>
           {{ else }}
-          <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">&mdash;</td>
+          <td>&mdash;</td>
           {{ end }}
         {{ end }}
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">{{ .Counterparty }}</td>
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+        <td>{{ .Counterparty }}</td>
+        <td>
           <div>
             <ul>
               <li>{{ .Originator }}</li>
@@ -91,7 +91,7 @@
             </ul>
           </div>
         </td>
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">
+        <td>
           <div>
             <ul>
               <li>{{ .Beneficiary }}</li>
@@ -103,17 +103,22 @@
             </ul>
           </div>
         </td>
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">{{ .VirtualAsset }}</td>
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">{{ .Amount }}</td>
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">{{ .EnvelopeCount }}</td>
+        <td>{{ .VirtualAsset }}</td>
+        <td>{{ .Amount }}</td>
+        <td>{{ .EnvelopeCount }}</td>
         {{ $created := .Created.Format "January 2, 2006 15:04:05" }}
-        <td class="cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">{{ $created }}</td>
+        <td>{{ $created }}</td>
+        {{ if .LastUpdate.IsZero  }}
+        <td>&mdash;</td>
+        {{ else }}
         {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 15:04:05" }}
-        <td class="trans-last-update cursor-pointer" onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">{{ $lastUpdate }}</td>
+        <td class="trans-last-update">{{ $lastUpdate }}</td>
+        {{ end }}
         <td>
           <div class="dropdown">
             <div tabindex="0" role="button" class="btn btn-ghost fobt-bold text-xl">&hellip;</div>
             <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-[#2F4858] font-semibold text-white rounded-box">
+              <li><a onclick="transaction_modal.showModal()" hx-get="/v1/transactions/{{ .ID }}" hx-target="#transaction_modal" hx-swap="innerHTML">View</a></li>
               {{ if eq .Source "remote" }}
               <li><a>Accept</a></li>
               <li><a>Reject</a></li>

--- a/pkg/web/templates/transactions.html
+++ b/pkg/web/templates/transactions.html
@@ -48,12 +48,14 @@
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1/plugin/relativeTime.js"></script>
 <script>dayjs.extend(window.dayjs_plugin_relativeTime)</script>
 <script type="text/javascript">
-  document.body.addEventListener('htmx:afterSettle', () => {
-    document.querySelectorAll('.trans-last-update').forEach((e) => {
+  document.body.addEventListener('htmx:afterSettle', (event) => {
+    if (event.detail.requestConfig.path === '/v1/transactions' && event.detail.requestConfig.verb === 'get') {
+      document.querySelectorAll('.trans-last-update').forEach((e) => {
       const transLastUpdate = e.textContent;
       const humanizeLastUpdate = dayjs(transLastUpdate).fromNow();
       e.textContent = humanizeLastUpdate;
     });
+    }
   });
 </script>
 {{ end }}


### PR DESCRIPTION
### Scope of changes

- Fixes a bug causing the last update time for a transaction to reset when users viewed the transaction detail modal. 
- Ensures the last update time is stored in the db.
- Displays a `-` if the last update time is null.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/27446781?key=1f708a13ed6cacab97278db3e851b7e1

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.
- [ ] Is the last update time accurate when viewed locally?


