### PR TITLE
Safari Login Localhost

### DIFF
--- a/pkg/web/auth/errors.go
+++ b/pkg/web/auth/errors.go
@@ -17,7 +17,7 @@ var (
 	ErrNotAuthorized     = errors.New("user does not have permission to perform this operation")
 	ErrNoAuthUser        = errors.New("could not identify authenticated user in request")
 	ErrParseBearer       = errors.New("could not parse Bearer token from Authorization header")
-	ErrNoAuthorization   = errors.New("no authorization header in request")
+	ErrNoAuthorization   = errors.New("no authorization header or cookies in request")
 	ErrNoRefreshToken    = errors.New("cannot reauthenticate no refresh token in request")
 	ErrNotAccepted       = errors.New("the accepted formats are not offered by the server")
 )

--- a/pkg/web/auth/middleware.go
+++ b/pkg/web/auth/middleware.go
@@ -152,9 +152,15 @@ func SetAuthCookies(c *gin.Context, accessToken, refreshToken, domain string) (e
 		return err
 	}
 
+	// Secure is true unless the domain is localhost
+	secure := true
+	if domain == "localhost" {
+		secure = false
+	}
+
 	// Set the access token cookie: httpOnly is true; cannot be accessed by Javascript
 	accessMaxAge := int((time.Until(accessExpires.Add(CookieMaxAgeBuffer))).Seconds())
-	c.SetCookie(AccessTokenCookie, accessToken, accessMaxAge, "/", domain, true, true)
+	c.SetCookie(AccessTokenCookie, accessToken, accessMaxAge, "/", domain, secure, true)
 
 	// Parse refresh token to get expiration time
 	var refreshExpires time.Time
@@ -164,7 +170,7 @@ func SetAuthCookies(c *gin.Context, accessToken, refreshToken, domain string) (e
 
 	// Set the refresh token cookie: httpOnly is false; can be accessed by Javascript
 	refreshMaxAge := int((time.Until(refreshExpires.Add(CookieMaxAgeBuffer))).Seconds())
-	c.SetCookie(RefreshTokenCookie, refreshToken, refreshMaxAge, "/", domain, true, false)
+	c.SetCookie(RefreshTokenCookie, refreshToken, refreshMaxAge, "/", domain, secure, false)
 	return nil
 }
 


### PR DESCRIPTION
### Scope of changes

Changes the `secure` flag on the cookies to `false` if the domain is localhost. This will allow us to login with Safari locally for testing and development without having to use TLS.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Any security concerns with this that I didn't think of?

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


