### PR TITLE
Display ivms101 data in transaction accept form

### DIFF
--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -867,16 +867,6 @@ html {
     opacity: 1;
   }
 
-  .btm-nav > *.disabled:hover,
-      .btm-nav > *[disabled]:hover {
-    pointer-events: none;
-    --tw-border-opacity: 0;
-    background-color: var(--fallback-n,oklch(var(--n)/var(--tw-bg-opacity)));
-    --tw-bg-opacity: 0.1;
-    color: var(--fallback-bc,oklch(var(--bc)/var(--tw-text-opacity)));
-    --tw-text-opacity: 0.2;
-  }
-
   .btn:hover {
     --tw-border-opacity: 1;
     border-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-border-opacity)));
@@ -1330,16 +1320,6 @@ html {
   color: var(--fallback-erc,oklch(var(--erc)/var(--tw-text-opacity)));
   --alert-bg: var(--fallback-er,oklch(var(--er)/1));
   --alert-bg-mix: var(--fallback-b1,oklch(var(--b1)/1));
-}
-
-.btm-nav > *.disabled,
-    .btm-nav > *[disabled] {
-  pointer-events: none;
-  --tw-border-opacity: 0;
-  background-color: var(--fallback-n,oklch(var(--n)/var(--tw-bg-opacity)));
-  --tw-bg-opacity: 0.1;
-  color: var(--fallback-bc,oklch(var(--bc)/var(--tw-text-opacity)));
-  --tw-text-opacity: 0.2;
 }
 
 .btm-nav > * .label {
@@ -2652,10 +2632,6 @@ html {
 
 .transform {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.cursor-not-allowed {
-  cursor: not-allowed;
 }
 
 .grid-cols-2 {

--- a/pkg/web/templates/partials/transaction/transaction_accept.html
+++ b/pkg/web/templates/partials/transaction/transaction_accept.html
@@ -105,7 +105,7 @@
 
         {{ range .Envelope.Identity.Originator.AccountNumbers }}
         <div>
-          <label for="orig_account_numbers">Account Number</label>
+          <label for="orig_account_numbers" class="label-style">Account Number</label>
           <input type="text" id="orig_account_numbers" name="orig_account_numbers" value="{{ . }}"
             class="input-style" />
         </div>
@@ -286,12 +286,12 @@
             value="{{ $nationalIdentification.CountryOfIssue }}" class="input-style" />
         </div>
         <div>
-          <label for="orig_vasp_registration_authority">Registration Authority</label>
+          <label for="orig_vasp_registration_authority" class="label-style">Registration Authority</label>
           <input type="text" id="orig_vasp_registration_authority" name="orig_vasp_registration_authority"
             value="{{ $nationalIdentification.RegistrationAuthority }}" class="input-style" />
         </div>
         <div>
-          <label for="orig_vasp_country_of_registration">Country of Registration</label>
+          <label for="orig_vasp_country_of_registration" class="label-style">Country of Registration</label>
           <input type="text" id="orig_vasp_country_of_registration" name="orig_vasp_country_of_registration"
             value="{{ $originatingVasp.CountryOfRegistration }}" />
         </div>
@@ -374,12 +374,12 @@
             value="{{ $beneficiaryNationalIdentification.CountryOfIssue }}" class="input-style" />
         </div>
         <div>
-          <label for="benf_vasp_registration_authority">Registration Authority</label>
+          <label for="benf_vasp_registration_authority" class="label-style">Registration Authority</label>
           <input type="text" id="benf_vasp_registration_authority" name="benf_vasp_registration_authority"
             value="{{ $beneficiaryNationalIdentification.RegistrationAuthority }}" class="input-style" />
         </div>
         <div>
-          <label for="benf_vasp_country_of_registration">Country of Registration</label>
+          <label for="benf_vasp_country_of_registration" class="label-style">Country of Registration</label>
           <input type="text" id="benf_vasp_country_of_registration" name="benf_vasp_country_of_registration"
             value="{{ $beneficiaryVasp.CountryOfRegistration }}" />
         </div>

--- a/pkg/web/templates/partials/transaction/transaction_accept.html
+++ b/pkg/web/templates/partials/transaction/transaction_accept.html
@@ -1,58 +1,385 @@
 <section class="my-4">
+  {{ if .Envelope }}
   <section>
     <div class="mb-4 md:mb-0">
-      <span class="font-semibold">Transaction ID: {{ .ID }}</span>
+      <span class="font-semibold">Transaction ID: {{ .Envelope.Transaction.Txid }}</span>
     </div>
   </section>
-  <form id="transaction-accept">
-    <section class="py-2 border-t border-t-black ">
+  <form id="transaction-accept" hx-post="/v1/transactions/{{ .Envelope.Transaction.Txid }}/send" hx-swap="none"
+    method="post">
+    <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">1. TRANSACTION DETAILS</h2>
-      <input id="id" type="hidden" name="id" value="{{ .ID }}" />
-      <input id="source" type="hidden" name="source" value="{{ .Source }}" />
-      <input id="status" type="hidden" name="status" value="{{ .Status }}" />
       <div class="grid gap-6 my-4 md:grid-cols-2">
         <div>
-          <label for="counterparty" class="label-style">Counterparty</label>
-          <input type="text" id="counterparty" name="counterparty" value="{{ .Counterparty }}" class="input-style" />
+          <label for="originator" class="label-style">Originator Address</label>
+          <input type="text" id="originator" name="originator" value="{{ .Envelope.Transaction.Originator }}"
+            class="input-style" />
         </div>
         <div>
-          <label for="counterparty_id" class="label-style">Counterparty ID</label>
-          <input disabled type="text" id="counterparty_id" name="counterparty_id" value="{{ .CounterpartyID }}" class="input-style cursor-not-allowed" />
+          <label for="beneficiary" class="label-style">Beneficiary Address</label>
+          <input type="text" id="beneficiary" name="beneficiary" value="{{ .Envelope.Transaction.Beneficiary }}"
+            class="input-style" />
         </div>
-      </div>
-      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <!-- TODO: Replace input with select -->
         <div>
-          <label for="originator" class="label-style">Originator</label>
-          <input type="text" id="originator" name="originator" value="{{ .Originator }}" class="input-style" />
-        </div>
-        <div>
-          <label for="originator_address" class="label-style">Originator Address</label>
-          <input type="text" id="originator_address" name="originator_address" value="{{ .OriginatorAddress }}" class="input-style" />
-        </div>
-        <div>
-          <label for="beneficiary" class="label-style">Beneficiary</label>
-          <input type="text" id="beneficiary" name="beneficiary" value="{{ .Beneficiary }}" class="input-style" />
-        </div>
-        <div>
-          <label for="beneficiary_address" class="label-style">Beneficiary Address</label>
-          <input type="text" id="beneficiary_address" name="beneficiary_address" value="{{ .BeneficiaryAddress }}" class="input-style" />
-        </div>
-        <div>
-          <label for="transaction-networks" class="label-style">Virtual Asset</label>
-          <select id="transaction-networks" name="virtual_asset"></select>
-          <input type="hidden" id="selected-network" value="{{ .VirtualAsset }}" />
+          <label for="network" class="label-style">Network</label>
+          <input type="text" id="network" name="network" value="{{ .Envelope.Transaction.Network }}" />
         </div>
         <div>
           <label for="amount" class="label-style">Amount</label>
-          <input id="amount" name="amount" value="{{ .Amount }}" class="input-style" />
+          <input id="amount" name="amount" value="{{ .Envelope.Transaction.Amount }}" class="input-style" />
+        </div>
+      </div>
+    </section>
+    <section class="py-2 border-t border-t-black">
+      <h2 class="my-4 font-bold">2. ORIGINATOR DETAILS</h2>
+      {{ $originator := (index .Envelope.Identity.Originator.OriginatorPersons 0).Person.NaturalPerson }}
+      {{ $originatorName := $originator.Name.NameIdentifiers }}
+      {{ $originatorAddress := $originator.GeographicAddresses }}
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        {{ range $originatorName }}
+        <div>
+          <label for="orig_primary_identifier" class="label-style">Primary Identifier</label>
+          <input type="text" id="orig_primary_identifier" name="orig_primary_identifier" value="{{ .PrimaryIdentifier}}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="orig_secondary_identifier" class="label-style">Secondary Identifier</label>
+          <input type="text" id="orig_secondary_identifier" name="orig_secondary_identifier" value="{{ .SecondaryIdentifier }}"
+            class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select -->
+        <div>
+          <label for="orig_name_identifier_type" class="label-style">Name Identifier Type</label>
+          <input type="text" id="orig_name_identifier_type" name="orig_name_identifier_type" value="{{ .NameIdentifierType }}"
+            class="input-style" />
+        </div>
+        {{ end }}
+
+        {{ range $originatorAddress }}
+        <div>
+          <label for="orig_street_name" class="label-style">Street Address</label>
+          <input type="text" id="orig_street_name" name="orig_street_name" value="{{ .StreetName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_building_number" class="label-style">Building Number</label>
+          <input type="text" id="orig_building_number" name="orig_building_number" value="{{ .BuildingNumber }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="orig_town_name" class="label-style">City/Municipality</label>
+          <input type="text" id="orig_town_name" name="orig_town_name" value="{{ .TownName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_district_name" class="label-style">Region/Province/State</label>
+          <input type="text" id="orig_district_name" name="orig_district_name" value="{{ .DistrictName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_post_code" class="label-style">Postal Code</label>
+          <input type="text" id="orig_post_code" name="orig_post_code" value="{{ .PostCode }}" class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select element -->
+        <div>
+          <label for="orig_country" class="label-style">Country</label>
+          <input type="text" id="orig_country" name="orig_country" value="{{ .Country }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_address_type" class="label-style">Address Type</label>
+          <input type="text" id="orig_address_type" name="orig_address_type" value="{{ .AddressType }}" class="input-style" />
+        </div>
+        {{ end }}
+
+        <div>
+          <label for="orig_country_of_residence" class="label-style">Country of Residence</label>
+          <input type="text" id="orig_country_of_residence" name="orig_country_of_residence"
+            value="{{ $originator.CountryOfResidence }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_customer_identification" class="label-style">Customer Identification</label>
+          <input type="text" id="orig_customer_identification" name="orig_customer_identification"
+            value="{{ $originator.CustomerIdentification }}" class="input-style" />
+        </div>
+
+        {{ range .Envelope.Identity.Originator.AccountNumbers }}
+        <div>
+          <label for="orig_account_numbers">Account Number</label>
+          <input type="text" id="orig_account_numbers" name="orig_account_numbers" value="{{ . }}" class="input-style" />
+        </div>
+        {{ end }}
+      </div>
+    </section>
+    <section class="py-2 border-t border-t-black">
+      <h2 class="my-4 font-bold">3. BENEFICIARY DETAILS </h2>
+      {{ $beneficiary := (index .Envelope.Identity.Beneficiary.BeneficiaryPersons 0).Person.NaturalPerson }}
+      {{ $beneficiaryName := $beneficiary.Name.NameIdentifiers }}
+      {{ $beneficiaryAddress := $beneficiary.GeographicAddresses }}
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        {{ range $beneficiaryName }}
+        <div>
+          <label for="benf_primary_identifier" class="label-style">Primary Identifier</label>
+          <input type="text" id="benf_primary_identifier" name="benf_primary_identifier" value="{{ .PrimaryIdentifier}}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="benf_secondary_identifier" class="label-style">Secondary Identifier</label>
+          <input type="text" id="benf_secondary_identifier" name="benf_secondary_identifier" value="{{ .SecondaryIdentifier }}"
+            class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select -->
+        <div>
+          <label for="benf_name_identifier_type" class="label-style">Name Identifier Type</label>
+          <input type="text" id="benf_name_identifier_type" name="benf_name_identifier_type" value="{{ .NameIdentifierType }}"
+            class="input-style" />
+        </div>
+        {{ end }}
+
+        {{ range $beneficiaryAddress }}
+        <div>
+          <label for="benf_street_name" class="label-style">Street Address</label>
+          <input type="text" id="benf_street_name" name="benf_street_name" value="{{ .StreetName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_building_number" class="label-style">Building Number</label>
+          <input type="text" id="benf_building_number" name="benf_building_number" value="{{ .BuildingNumber }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="benf_town_name" class="label-style">City/Municipality</label>
+          <input type="text" id="benf_town_name" name="benf_town_name" value="{{ .TownName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_district_name" class="label-style">Region/Province/State</label>
+          <input type="text" id="benf_district_name" name="benf_district_name" value="{{ .DistrictName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_post_code" class="label-style">Postal Code</label>
+          <input type="text" id="benf_post_code" name="benf_post_code" value="{{ .PostCode }}" class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select element -->
+        <div>
+          <label for="benf_country" class="label-style">Country</label>
+          <input type="text" id="benf_country" name="benf_country" value="{{ .Country }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_address_type" class="label-style">Address Type</label>
+          <input type="text" id="benf_address_type" name="benf_address_type" value="{{ .AddressType }}" class="input-style" />
+        </div>
+        {{ end }}
+
+        <div>
+          <label for="benf_country_of_residence" class="label-style">Country of Residence</label>
+          <input type="text" id="benf_country_of_residence" name="benf_country_of_residence"
+            value="{{ $beneficiary.CountryOfResidence }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_customer_identification" class="label-style">Customer Identification</label>
+          <input type="text" id="benf_customer_identification" name="benf_customer_identification"
+            value="{{ $beneficiary.CustomerIdentification }}" class="input-style" />
+        </div>
+
+        {{ range .Envelope.Identity.Beneficiary.AccountNumbers }}
+        <div>
+          <label for="benf_account_numbers" class="label-style">Account Number</label>
+          <input type="text" id="benf_account_numbers" name="benf_account_numbers" value="{{ . }}" class="input-style" />
+        </div>
+        {{ end }}
+      </div>
+    </section>
+    <section class="py-2 border-t border-t-black">
+      <h2 class="my-4 font-bold">4. ORIGINATING VASP DETAILS </h2>
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        {{ $originatingVasp := .Envelope.Identity.OriginatingVasp.OriginatingVasp.Person.LegalPerson }}
+        {{ $originatingLegalPerson := $originatingVasp.Name }}
+
+        {{ range $originatingLegalPerson.NameIdentifiers }}
+        <div>
+          <label for="orig_vasp_legal_person_name" class="label-style">Legal Person Name</label>
+          <input type="text" id="orig_vasp_legal_person_name" name="orig_vasp_legal_person_name" value="{{ .LegalPersonName }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier Type</label>
+          <input type="text" id="orig_vasp_legal_person_name_identifier_type" name="orig_vasp_legal_person_name_identifier_type"
+            value="{{ .LegalPersonNameIdentifierType }}" class="input-style" />
+        </div>
+        {{ end }}
+
+        {{ range $originatingLegalPerson.LocalNameIdentifiers }}
+        <div>
+          <label for="orig_vasp_local_legal_name" class="label-style">Local Name Primary Identifier</label>
+          <input type="text" id="orig_vasp_local_legal_name" name="orig_vasp_local_legal_name" value="{{ .LegalPersonName }}"
+            class="input-style" />
+        </div>
+        <!-- TODO: Replace identifier type input with select -->
+        <div>
+          <label for="orig_vasp_local_legal_name_identifier_type" class="label-style">Local Name Identifier Type</label>
+          <input type="text" id="orig_vasp_local_legal_name_identifier_type" name="orig_vasp_local_legal_name_identifier_type"
+            value="{{ .LegalPersonNameIdentifierType }}" class="input-style" />
+        </div>
+        {{ end }}
+
+        {{ range $originatingVasp.GeographicAddresses }}
+        <div>
+          <label for="orig_vasp_street_name" class="label-style">Street Address</label>
+          <input type="text" id="orig_vasp_street_name" name="orig_vasp_street_name"
+            value="{{ .StreetName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_building_number" class="label-style">Building Number</label>
+          <input type="text" id="orig_vasp_building_number" name="orig_vasp_building_number"
+            value="{{ .BuildingNumber }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_town_name" class="label-style">City/Municipality</label>
+          <input type="text" id="orig_vasp_town_name" name="orig_vasp_town_name" value="{{ .TownName }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_district_name" class="label-style">Region/Province/State</label>
+          <input type="text" id="orig_vasp_district_name" name="orig_vasp_district_name"
+            value="{{ .DistrictName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_post_code" class="label-style">Postal Code</label>
+          <input type="text" id="orig_vasp_post_code" name="orig_vasp_post_code" value="{{ .PostCode }}"
+            class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select element -->
+        <div>
+          <label for="orig_vasp_country" class="label-style">Country</label>
+          <input type="text" id="orig_vasp_country" name="orig_vasp_country" value="{{ .Country }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_address_type" class="label-style">Address Type</label>
+          <input type="text" id="orig_vasp_address_type" name="orig_vasp_address_type"
+            value="{{ .AddressType }}" class="input-style" />
+        </div>
+        {{ end }}
+
+        {{ $nationalIdentification := $originatingVasp.NationalIdentification }}
+        <div>
+          <label for="orig_vasp_national_identifier" class="label-style">National Identifier</label>
+          <input type="text" id="orig_vasp_national_identifier" name="orig_vasp_national_identifier"
+            value="{{ $nationalIdentification.NationalIdentifier }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_national_identifier_type" class="label-style">National Identifier Type</label>
+          <input type="text" id="orig_vasp_national_identifier_type" name="orig_vasp_national_identifier_type"
+            value="{{ $nationalIdentification.NationalIdentifierType }}" class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select -->
+        <div>
+          <label for="orig_vasp_country_of_issue" class="label-style">Country of Issue</label>
+          <input type="text" id="orig_vasp_country_of_issue" name="orig_vasp_country_of_issue"
+            value="{{ $nationalIdentification.CountryOfIssue }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_registration_authority">Registration Authority</label>
+          <input type="text" id="orig_vasp_registration_authority" name="orig_vasp_registration_authority"
+            value="{{ $nationalIdentification.RegistrationAuthority }}" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_country_of_registration">Country of Registration</label>
+          <input type="text" id="orig_vasp_country_of_registration" name="orig_vasp_country_of_registration"
+            value="{{ $originatingVasp.CountryOfRegistration }}" />
+        </div>
+      </div>
+    </section>
+    <section class="py-2 border-t border-t-black">
+      <h2 class="my-4 font-bold">5. BENEFICIARY VASP DETAILS </h2>
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        {{ $beneficiaryVasp := .Envelope.Identity.BeneficiaryVasp.BeneficiaryVasp.Person.LegalPerson }}
+
+        {{ range $beneficiaryVasp.NameIdentifiers }}
+        <div>
+          <label for="benf_vasp_legal_person_name" class="label-style">Name Identifier</label>
+          <input type="text" id="benf_vasp_legal_person_name" name="benf_vasp_legal_person_name"
+            value="{{ .LegalPersonName }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier
+            Type</label>
+          <input type="text" id="benf_vasp_legal_person_name_identifier_type"
+            name="benf_vasp_legal_person_name_identifier_type" value="{{ .LegalPersonNameIdentifierType }}"
+            class="input-style" />
+        </div>
+        {{ end }}
+
+        {{ range $beneficiaryVasp.GeographicAddresses }}
+        <div>
+          <label for="benf_vasp_street_name" class="label-style">Street Address</label>
+          <input type="text" id="benf_vasp_street_name" name="benf_vasp_street_name" value="{{ .StreetName }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_building_number" class="label-style">Building Number</label>
+          <input type="text" id="benf_vasp_building_number" name="benf_vasp_building_number"
+            value="{{ .BuildingNumber }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_town_name" class="label-style">City/Municipality</label>
+          <input type="text" id="benf_vasp_town_name" name="benf_vasp_town_name" value="{{ .TownName }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_district_name" class="label-style">Region/Province/State</label>
+          <input type="text" id="benf_vasp_district_name" name="benf_vasp_district_name" value="{{ .DistrictName }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_post_code" class="label-style">Postal Code</label>
+          <input type="text" id="benf_vasp_post_code" name="benf_vasp_post_code" value="{{ .PostCode }}"
+            class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select element -->
+        <div>
+          <label for="benf_vasp_country" class="label-style">Country</label>
+          <input type="text" id="benf_vasp_country" name="benf_vasp_country" value="{{ .Country }}"
+            class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_address_type" class="label-style">Address Type</label>
+          <input type="text" id="benf_vasp_address_type" name="benf_vasp_address_type" value="{{ .AddressType }}"
+            class="input-style" />
+        </div>
+        {{ end }}
+
+        {{ $beneficiaryNationalIdentification := $beneficiaryVasp.NationalIdentification }}
+        <div>
+          <label for="benf_vasp_national_identifier" class="label-style">National Identifier</label>
+          <input type="text" id="benf_vasp_national_identifier" name="benf_vasp_national_identifier"
+            value="{{ $beneficiaryNationalIdentification.NationalIdentifier }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_national_identifier_type" class="label-style">National Identifier Type</label>
+          <input type="text" id="benf_vasp_national_identifier_type" name="benf_vasp_national_identifier_type"
+            value="{{ $beneficiaryNationalIdentification.NationalIdentifierType }}" class="input-style" />
+        </div>
+        <!-- TODO: Replace input with select -->
+        <div>
+          <label for="benf_vasp_country_of_issue" class="label-style">Country of Issue</label>
+          <input type="text" id="benf_vasp_country_of_issue" name="benf_vasp_country_of_issue"
+            value="{{ $beneficiaryNationalIdentification.CountryOfIssue }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_registration_authority">Registration Authority</label>
+          <input type="text" id="benf_vasp_registration_authority" name="benf_vasp_registration_authority"
+            value="{{ $beneficiaryNationalIdentification.RegistrationAuthority }}" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_country_of_registration">Country of Registration</label>
+          <input type="text" id="benf_vasp_country_of_registration" name="benf_vasp_country_of_registration"
+            value="{{ $beneficiaryVasp.CountryOfRegistration }}" />
         </div>
       </div>
     </section>
     <div class="py-4 flex justify-center items-center gap-x-2">
-      {{ if eq .Source "remote" }}
-      <button type="submit" hx-post="/v1/transactions/{{ .ID }}/send" hx-swap="none" class="p-1 rounded w-36 bg-green-700 font-semibold text-white md:p-2 hover:bg-green-700/80">Accept</button>
-      {{ end }}
-      <a href="/transactions/{{ .ID }}/info" class="p-1 rounded w-36 bg-red-700 font-semibold text-white text-center md:p-2 hover:bg-red-700/80">Cancel</a>
+      <button type="submit"
+        class="p-1 rounded w-36 bg-green-700 font-semibold text-white md:p-2 hover:bg-green-700/80">Accept</button>
+      <a href="/transactions/{{ .Envelope.Transaction.Txid }}/info"
+        class="p-1 rounded w-36 bg-red-700 font-semibold text-white text-center md:p-2 hover:bg-red-700/80">Cancel</a>
     </div>
   </form>
+  {{ end }}
 </section>

--- a/pkg/web/templates/partials/transaction/transaction_accept.html
+++ b/pkg/web/templates/partials/transaction/transaction_accept.html
@@ -45,21 +45,22 @@
         </div>
         <div>
           <label for="orig_secondary_identifier" class="label-style">Secondary Identifier</label>
-          <input type="text" id="orig_secondary_identifier" name="orig_secondary_identifier" value="{{ .SecondaryIdentifier }}"
-            class="input-style" />
+          <input type="text" id="orig_secondary_identifier" name="orig_secondary_identifier"
+            value="{{ .SecondaryIdentifier }}" class="input-style" />
         </div>
         <!-- TODO: Replace input with select -->
         <div>
           <label for="orig_name_identifier_type" class="label-style">Name Identifier Type</label>
-          <input type="text" id="orig_name_identifier_type" name="orig_name_identifier_type" value="{{ .NameIdentifierType }}"
-            class="input-style" />
+          <input type="text" id="orig_name_identifier_type" name="orig_name_identifier_type"
+            value="{{ .NameIdentifierType }}" class="input-style" />
         </div>
         {{ end }}
 
         {{ range $originatorAddress }}
         <div>
           <label for="orig_street_name" class="label-style">Street Address</label>
-          <input type="text" id="orig_street_name" name="orig_street_name" value="{{ .StreetName }}" class="input-style" />
+          <input type="text" id="orig_street_name" name="orig_street_name" value="{{ .StreetName }}"
+            class="input-style" />
         </div>
         <div>
           <label for="orig_building_number" class="label-style">Building Number</label>
@@ -72,7 +73,8 @@
         </div>
         <div>
           <label for="orig_district_name" class="label-style">Region/Province/State</label>
-          <input type="text" id="orig_district_name" name="orig_district_name" value="{{ .DistrictName }}" class="input-style" />
+          <input type="text" id="orig_district_name" name="orig_district_name" value="{{ .DistrictName }}"
+            class="input-style" />
         </div>
         <div>
           <label for="orig_post_code" class="label-style">Postal Code</label>
@@ -85,7 +87,8 @@
         </div>
         <div>
           <label for="orig_address_type" class="label-style">Address Type</label>
-          <input type="text" id="orig_address_type" name="orig_address_type" value="{{ .AddressType }}" class="input-style" />
+          <input type="text" id="orig_address_type" name="orig_address_type" value="{{ .AddressType }}"
+            class="input-style" />
         </div>
         {{ end }}
 
@@ -103,7 +106,8 @@
         {{ range .Envelope.Identity.Originator.AccountNumbers }}
         <div>
           <label for="orig_account_numbers">Account Number</label>
-          <input type="text" id="orig_account_numbers" name="orig_account_numbers" value="{{ . }}" class="input-style" />
+          <input type="text" id="orig_account_numbers" name="orig_account_numbers" value="{{ . }}"
+            class="input-style" />
         </div>
         {{ end }}
       </div>
@@ -122,21 +126,22 @@
         </div>
         <div>
           <label for="benf_secondary_identifier" class="label-style">Secondary Identifier</label>
-          <input type="text" id="benf_secondary_identifier" name="benf_secondary_identifier" value="{{ .SecondaryIdentifier }}"
-            class="input-style" />
+          <input type="text" id="benf_secondary_identifier" name="benf_secondary_identifier"
+            value="{{ .SecondaryIdentifier }}" class="input-style" />
         </div>
         <!-- TODO: Replace input with select -->
         <div>
           <label for="benf_name_identifier_type" class="label-style">Name Identifier Type</label>
-          <input type="text" id="benf_name_identifier_type" name="benf_name_identifier_type" value="{{ .NameIdentifierType }}"
-            class="input-style" />
+          <input type="text" id="benf_name_identifier_type" name="benf_name_identifier_type"
+            value="{{ .NameIdentifierType }}" class="input-style" />
         </div>
         {{ end }}
 
         {{ range $beneficiaryAddress }}
         <div>
           <label for="benf_street_name" class="label-style">Street Address</label>
-          <input type="text" id="benf_street_name" name="benf_street_name" value="{{ .StreetName }}" class="input-style" />
+          <input type="text" id="benf_street_name" name="benf_street_name" value="{{ .StreetName }}"
+            class="input-style" />
         </div>
         <div>
           <label for="benf_building_number" class="label-style">Building Number</label>
@@ -149,7 +154,8 @@
         </div>
         <div>
           <label for="benf_district_name" class="label-style">Region/Province/State</label>
-          <input type="text" id="benf_district_name" name="benf_district_name" value="{{ .DistrictName }}" class="input-style" />
+          <input type="text" id="benf_district_name" name="benf_district_name" value="{{ .DistrictName }}"
+            class="input-style" />
         </div>
         <div>
           <label for="benf_post_code" class="label-style">Postal Code</label>
@@ -162,7 +168,8 @@
         </div>
         <div>
           <label for="benf_address_type" class="label-style">Address Type</label>
-          <input type="text" id="benf_address_type" name="benf_address_type" value="{{ .AddressType }}" class="input-style" />
+          <input type="text" id="benf_address_type" name="benf_address_type" value="{{ .AddressType }}"
+            class="input-style" />
         </div>
         {{ end }}
 
@@ -180,7 +187,8 @@
         {{ range .Envelope.Identity.Beneficiary.AccountNumbers }}
         <div>
           <label for="benf_account_numbers" class="label-style">Account Number</label>
-          <input type="text" id="benf_account_numbers" name="benf_account_numbers" value="{{ . }}" class="input-style" />
+          <input type="text" id="benf_account_numbers" name="benf_account_numbers" value="{{ . }}"
+            class="input-style" />
         </div>
         {{ end }}
       </div>
@@ -194,35 +202,38 @@
         {{ range $originatingLegalPerson.NameIdentifiers }}
         <div>
           <label for="orig_vasp_legal_person_name" class="label-style">Legal Person Name</label>
-          <input type="text" id="orig_vasp_legal_person_name" name="orig_vasp_legal_person_name" value="{{ .LegalPersonName }}"
-            class="input-style" />
+          <input type="text" id="orig_vasp_legal_person_name" name="orig_vasp_legal_person_name"
+            value="{{ .LegalPersonName }}" class="input-style" />
         </div>
         <div>
-          <label for="orig_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier Type</label>
-          <input type="text" id="orig_vasp_legal_person_name_identifier_type" name="orig_vasp_legal_person_name_identifier_type"
-            value="{{ .LegalPersonNameIdentifierType }}" class="input-style" />
+          <label for="orig_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier
+            Type</label>
+          <input type="text" id="orig_vasp_legal_person_name_identifier_type"
+            name="orig_vasp_legal_person_name_identifier_type" value="{{ .LegalPersonNameIdentifierType }}"
+            class="input-style" />
         </div>
         {{ end }}
 
         {{ range $originatingLegalPerson.LocalNameIdentifiers }}
         <div>
           <label for="orig_vasp_local_legal_name" class="label-style">Local Name Primary Identifier</label>
-          <input type="text" id="orig_vasp_local_legal_name" name="orig_vasp_local_legal_name" value="{{ .LegalPersonName }}"
-            class="input-style" />
+          <input type="text" id="orig_vasp_local_legal_name" name="orig_vasp_local_legal_name"
+            value="{{ .LegalPersonName }}" class="input-style" />
         </div>
         <!-- TODO: Replace identifier type input with select -->
         <div>
           <label for="orig_vasp_local_legal_name_identifier_type" class="label-style">Local Name Identifier Type</label>
-          <input type="text" id="orig_vasp_local_legal_name_identifier_type" name="orig_vasp_local_legal_name_identifier_type"
-            value="{{ .LegalPersonNameIdentifierType }}" class="input-style" />
+          <input type="text" id="orig_vasp_local_legal_name_identifier_type"
+            name="orig_vasp_local_legal_name_identifier_type" value="{{ .LegalPersonNameIdentifierType }}"
+            class="input-style" />
         </div>
         {{ end }}
 
         {{ range $originatingVasp.GeographicAddresses }}
         <div>
           <label for="orig_vasp_street_name" class="label-style">Street Address</label>
-          <input type="text" id="orig_vasp_street_name" name="orig_vasp_street_name"
-            value="{{ .StreetName }}" class="input-style" />
+          <input type="text" id="orig_vasp_street_name" name="orig_vasp_street_name" value="{{ .StreetName }}"
+            class="input-style" />
         </div>
         <div>
           <label for="orig_vasp_building_number" class="label-style">Building Number</label>
@@ -236,8 +247,8 @@
         </div>
         <div>
           <label for="orig_vasp_district_name" class="label-style">Region/Province/State</label>
-          <input type="text" id="orig_vasp_district_name" name="orig_vasp_district_name"
-            value="{{ .DistrictName }}" class="input-style" />
+          <input type="text" id="orig_vasp_district_name" name="orig_vasp_district_name" value="{{ .DistrictName }}"
+            class="input-style" />
         </div>
         <div>
           <label for="orig_vasp_post_code" class="label-style">Postal Code</label>
@@ -252,8 +263,8 @@
         </div>
         <div>
           <label for="orig_vasp_address_type" class="label-style">Address Type</label>
-          <input type="text" id="orig_vasp_address_type" name="orig_vasp_address_type"
-            value="{{ .AddressType }}" class="input-style" />
+          <input type="text" id="orig_vasp_address_type" name="orig_vasp_address_type" value="{{ .AddressType }}"
+            class="input-style" />
         </div>
         {{ end }}
 


### PR DESCRIPTION
### Scope of changes

This PR will display a form with ivms101 data on the transaction accept page.

Follow on stories will be created to manipulate the request data to match the ivms101 configuration. Also, country, network, and type are currently displayed via text inputs but this should be replaced with select elements.

Note: An incoming transaction with a secure envelope is required for testing.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Do any of the ivms101 fields appear to be missing?

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


