### PR TITLE
Amend secure envelope list style

### DIFF
--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2867,10 +2867,6 @@ details.collapse summary::-webkit-details-marker {
   margin-bottom: 3rem;
 }
 
-.mb-3 {
-  margin-bottom: 0.75rem;
-}
-
 .mb-4 {
   margin-bottom: 1rem;
 }
@@ -2917,6 +2913,14 @@ details.collapse summary::-webkit-details-marker {
 
 .mt-8 {
   margin-top: 2rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem;
 }
 
 .block {
@@ -3011,8 +3015,16 @@ details.collapse summary::-webkit-details-marker {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
+.auto-cols-auto {
+  grid-auto-columns: auto;
+}
+
 .grid-cols-2 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .flex-row {
@@ -3298,6 +3310,11 @@ details.collapse summary::-webkit-details-marker {
 .py-9 {
   padding-top: 2.25rem;
   padding-bottom: 2.25rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .pb-2 {
@@ -3675,6 +3692,31 @@ body main {
     left: calc(var(--tooltip-tail-offset) + 0.0625rem);
     right: auto;
     bottom: auto;
+  }
+}
+
+@media (min-width: 1024px) {
+  .lg\:divider-horizontal {
+    flex-direction: column;
+  }
+
+  .lg\:divider-horizontal:before {
+    height: 100%;
+    width: 0.125rem;
+  }
+
+  .lg\:divider-horizontal:after {
+    height: 100%;
+    width: 0.125rem;
+  }
+
+  .lg\:divider-horizontal {
+    margin-left: 1rem;
+    margin-right: 1rem;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    height: auto;
+    width: 1rem;
   }
 }
 

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2915,10 +2915,6 @@ details.collapse summary::-webkit-details-marker {
   margin-top: 2rem;
 }
 
-.mb-2 {
-  margin-bottom: 0.5rem;
-}
-
 .mb-3 {
   margin-bottom: 0.75rem;
 }
@@ -3015,16 +3011,8 @@ details.collapse summary::-webkit-details-marker {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
-.auto-cols-auto {
-  grid-auto-columns: auto;
-}
-
 .grid-cols-2 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.grid-cols-3 {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .flex-row {
@@ -3133,11 +3121,6 @@ details.collapse summary::-webkit-details-marker {
   border-color: rgb(209 213 219 / var(--tw-border-opacity)) !important;
 }
 
-.border-base-300 {
-  --tw-border-opacity: 1;
-  border-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-border-opacity)));
-}
-
 .border-black {
   --tw-border-opacity: 1;
   border-color: rgb(0 0 0 / var(--tw-border-opacity));
@@ -3150,6 +3133,11 @@ details.collapse summary::-webkit-details-marker {
 .border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
+.border-base-300 {
+  --tw-border-opacity: 1;
+  border-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-border-opacity)));
 }
 
 .border-b-black {
@@ -3310,11 +3298,6 @@ details.collapse summary::-webkit-details-marker {
 .py-9 {
   padding-top: 2.25rem;
   padding-bottom: 2.25rem;
-}
-
-.px-4 {
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
 .pb-2 {
@@ -3692,31 +3675,6 @@ body main {
     left: calc(var(--tooltip-tail-offset) + 0.0625rem);
     right: auto;
     bottom: auto;
-  }
-}
-
-@media (min-width: 1024px) {
-  .lg\:divider-horizontal {
-    flex-direction: column;
-  }
-
-  .lg\:divider-horizontal:before {
-    height: 100%;
-    width: 0.125rem;
-  }
-
-  .lg\:divider-horizontal:after {
-    height: 100%;
-    width: 0.125rem;
-  }
-
-  .lg\:divider-horizontal {
-    margin-left: 1rem;
-    margin-right: 1rem;
-    margin-top: 0px;
-    margin-bottom: 0px;
-    height: auto;
-    width: 1rem;
   }
 }
 

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -1,20 +1,63 @@
-<section class="p-4">
-  <h2 class="text-xl font-bold">Secure Envelopes</h2>
-  {{ if .SecureEnvelopes }}
-  {{ range .SecureEnvelopes }}
-  <div class="join join-vertical w-full">
-    <div class="collapse collapse-plus join-item border border-base-300">
-      <input type="radio" name="my-accordion-4" checked="checked" />
-      <div class="collapse-title text-xl font-medium">
-        <div class="flex items-center gap-x-1">
-          <p>Envelope ID: {{ .EnvelopeID }}</p>
-        </div>
-      </div>
-      <div hx-get="/v1/transactions/{{ .ID }}/secure-envelopes/{{ .EnvelopeID }}" hx-trigger="load"></div>
-    </div>
-  </div>
+{{ if .DecryptedEnvelopes }}
+{{ range .DecryptedEnvelopes }}
+<p>Envelope ID: {{ .Envelope.Pending.EnvelopeID }}</p>
+<div class="flex items-center">
+  {{ $sentAt := .SentAt.Format "January 2, 2006 3:04:05 PM" }}
+  {{ $receivedAt := .ReceivedAt.Format "January 2, 2006 3:04:05 PM" }}
+  <p>
+    <span class="font-semibold">Sent at:</span>
+    {{ if .SentAt }} {{ $sentAt }} {{ else }} N/A {{ end }}
+  </p>
+  <p>
+    <span class="font-semibold">Received at:</span>
+    {{ if .ReceivedAt}} {{ $receivedAt }} {{ else }} N/A {{ end }}
+  </p>
   {{ end }}
-  {{ else }}
-  <p class="my-8 text-center">There are no secure envelopes for this transaction.</p>
+</div>
+<section>
+  <h3>On-chain Transaction Info</h3>
+  <dl>
+    <div class="grid grid-cols-2">
+      <dt>Blockchain Tx ID</dt>
+      {{ $txid := .Envelope.Transaction.Txid }}
+      <dd>{{ if $txid }} {{ $txid }} {{ else }} &mdash; {{ end }}</dd>
+    </div>
+    <div class="grid grid-cols-2">
+      <dt>Originator Wallet Address</dt>
+      {{ $originator := .Envelope.Transaction.Originator }}
+      <dd>{{ if $originator }} {{ $originator}} {{ else }} &mdash; {{ end }}</dd>
+    </div>
+    <div class="grid grid-cols-2">
+      <dt>Beneficiary Wallet Address</dt>
+      {{ $beneficiary := .Envelope.Transaction.Beneficiary }}
+      <dd>{{ if $beneficiary }} {{ $beneficiary }} {{ else }} &mdash; {{ end }}</dd>
+    </div>
+    <div class="flex items-center">
+      <div class="grid grid-cols-2">
+        <dt>Network</dt>
+        {{ $network := .Envelope.Transaction.Network }}
+        <dd>{{ if $network }} {{ $network }} {{ else }} &mdash; {{ end }}</dd>
+      </div>
+      <div class="grid grid-cols-2">
+        <dt>Asset Type</dt>
+        {{ $assetType := .Envelope.Transaction.AssetType }}
+        <dd>{{ if $assetType }} {{ $assetType }} {{ else }} &mdash; {{ end }}</dd>
+      </div>
+    </div>
+    <div class="grid grid-cols-2">
+      <dt>Transfer Amount</dt>
+      {{ $amount := .Envelope.Transaction.Amount }}
+      <dd>{{ if $amount }} {{ $amount }} {{ else }} &mdash; {{ end }}</dd>
+    </div>
+    <div class="grid grid-cols-2">
+      <dt>Destination Tag/Memo</dt>
+      {{ $tag := .Envelope.Transaction.Tag }}
+      <dd>{{ if $tag }} {{ $tag }} {{ else }} &mdash; {{ end }}</dd>
+    </div>
+  </dl>
 </section>
+<div hx-get="/v1/transactions/{{ .ID }}/secure-envelopes/{{ .EnvelopeID }}" hx-trigger="load"></div>
+{{ end }}
+{{ else }}
+<p class="my-8 text-center">There are no secure envelopes for this transaction.</p>
 {{ end }}

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -1,4 +1,4 @@
-<section>
+<section class="p-4">
   <h2 class="text-xl font-bold">Secure Envelopes</h2>
   {{ if .SecureEnvelopes }}
   {{ range .SecureEnvelopes }}
@@ -7,27 +7,10 @@
       <input type="radio" name="my-accordion-4" checked="checked" />
       <div class="collapse-title text-xl font-medium">
         <div class="flex items-center gap-x-1">
-          {{ if eq .Direction "in" }}
-          <div class="tooltip tooltip-right" data-tip="Incoming secure envelope">
-            <button>
-              <i class="fa-solid fa-file-import" title="Incoming secure envelope"></i>
-            </button>
-          </div>
-          {{ else }}
-          <div class="tooltip tooltip-right" data-tip="Outgoing secure envelope">
-            <button>
-              <i class="fa-solid fa-file-export" title="Outgoing envelope"></i>
-            </button>
-          </div>
-          {{ end }}
-          <h3 class="text-lg"><span class="font-semibold">Envelope ID:</span>{{ .EnvelopeID }}</h3>
-          {{ $timeStamp := .TimeStamp.Format "January 2, 2006 15:04:05" }}
-          <span>{{ $timeStamp }}</span>
+          <p>Envelope ID: {{ .EnvelopeID }}</p>
         </div>
       </div>
-      <div class="collapse-content">
-        <div hx-get="/v1/transactions/{{ .ID }}/secure-envelopes/{{ .EnvelopeID }}" hx-trigger="load"></div>
-      </div>
+      <div hx-get="/v1/transactions/{{ .ID }}/secure-envelopes/{{ .EnvelopeID }}" hx-trigger="load"></div>
     </div>
   </div>
   {{ end }}

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -12,7 +12,6 @@
     <span class="font-semibold">Received at:</span>
     {{ if .ReceivedAt}} {{ $receivedAt }} {{ else }} N/A {{ end }}
   </p>
-  {{ end }}
 </div>
 <section>
   <h3>On-chain Transaction Info</h3>
@@ -56,7 +55,8 @@
     </div>
   </dl>
 </section>
-<div hx-get="/v1/transactions/{{ .ID }}/secure-envelopes/{{ .EnvelopeID }}" hx-trigger="load"></div>
+<!-- TODO: Call the transaction detail content and style -->
+<!-- <div hx-get="/v1/transactions/{{ .ID }}/secure-envelopes/{{ .EnvelopeID }}" hx-trigger="load"></div> -->
 {{ end }}
 {{ else }}
 <p class="my-8 text-center">There are no secure envelopes for this transaction.</p>

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -10,7 +10,7 @@
   </p>
   <p>
     <span class="font-semibold">Received at:</span>
-    {{ if .ReceivedAt}} {{ $receivedAt }} {{ else }} N/A {{ end }}
+    {{ if .ReceivedAt }} {{ $receivedAt }} {{ else }} N/A {{ end }}
   </p>
 </div>
 <section>

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -1,4 +1,4 @@
-<div class="w-full">
+<div class="w-full border rounded">
   <div class="md:flex items-center justify-between p-4 border border-black rounded bg-[#D9D9D9]">
     <div class="mb-4 md:mb-0">
       <h1 class="text-xl mb-1 font-bold text-gray-900 lg:text-2xl">
@@ -18,10 +18,10 @@
         class="p-1 rounded w-32 bg-black font-semibold text-white text-center md:p-2 hover:bg-black/80">Back</a>
     </div>
   </div>
-  <div class="my-8 grid grid-cols-2 gap-x-6">
-    <section>
-      <div class="mb-3 bg-[#D9D9D9] p-2 rounded-md">
-        <h2 class="font-bold text-lg">Transfer Details</h2>
+  <div class="my-2 grid grid-cols-2 gap-x-6">
+    <section class="p-4">
+      <div class="">
+        <h2 class="font-bold text-lg">Transfer Details:</h2>
       </div>
       <dl>
         <div class="grid grid-cols-2 p-2">
@@ -81,9 +81,9 @@
       </dl>
     </section>
 
-    <section>
-      <div class="mb-3 bg-[#D9D9D9] p-2 rounded-md">
-        <h2 class="font-bold text-lg">Identity Details</h2>
+    <section class="p-4">
+      <div class="">
+        <h2 class="font-bold text-lg">Identity Details:</h2>
       </div>
       <dl>
         <div class="grid grid-cols-2 p-2">

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -26,20 +26,19 @@
       <dl>
         <div class="grid grid-cols-2 p-2">
           <dd class="font-bold">Type</dd>
-          <!-- TODO: Add tooltip style to icons -->
           {{ if eq .Source "local" }}
-          <div class="flex items-center gap-x-1">
-            <i class="fa-solid fa-file-export" title="Outgoing transaction from local VASP"></i>
+          <div class="flex tooltip" data-tip="Outgoing transaction from local VASP">
+            <button><i class="fa-solid fa-file-export"></i></button>
             <dt class="sr-only">Outgoing</dt>
           </div>
           {{ else if eq .Source "remote" }}
-          <div class="flex items-center gap-x-1">
-            <i class="fa-solid fa-file-import" title="Incoming transaction from remote VASP"></i>
+          <div class="flex tooltip" data-tip="Incoming transaction from remote VASP">
+            <button><i class="fa-solid fa-file-import"></i></button>
             <dt class="sr-only">Incoming</dt>
           </div>
           {{ else }}
-          <div class="flex items-center gap-x-1">
-            <i class="fa-solid fa-question" title="Unknown transaction type"></i>
+          <div class="flex tooltip" data-tip="Unknown transaction type">
+            <button><i class="fa-solid fa-question"></i></button>
             <dt class="sr-only">Unknown</dt>
           </div>
           {{ end }}

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -27,20 +27,11 @@
         <div class="grid grid-cols-2 p-2">
           <dd class="font-bold">Type</dd>
           {{ if eq .Source "local" }}
-          <div class="flex tooltip" data-tip="Outgoing transaction from local VASP">
-            <button><i class="fa-solid fa-file-export"></i></button>
-            <dt class="sr-only">Outgoing</dt>
-          </div>
+          <dt>Outgoing</dt>
           {{ else if eq .Source "remote" }}
-          <div class="flex tooltip" data-tip="Incoming transaction from remote VASP">
-            <button><i class="fa-solid fa-file-import"></i></button>
-            <dt class="sr-only">Incoming</dt>
-          </div>
-          {{ else }}
-          <div class="flex tooltip" data-tip="Unknown transaction type">
-            <button><i class="fa-solid fa-question"></i></button>
-            <dt class="sr-only">Unknown</dt>
-          </div>
+            <dt>Incoming</dt>
+            {{ else }}
+            <dt>Unknown</dt>
           {{ end }}
         </div>
         <div class="grid grid-cols-2 p-2">

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -118,3 +118,11 @@
     </section>
   </div>
 </div>
+<section class="p-4">
+  <h2 class="text-xl font-bold">Secure Envelopes ({{ .EnvelopeCount }})</h2>
+  <div class="my-4" hx-get="/v1/transactions/{{ .ID }}/secure-envelopes" hx-trigger="load" hx-swap="beforeend">
+    <div class="text-center">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+  </div>
+</section>

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -118,9 +118,10 @@
     </section>
   </div>
 </div>
-<section class="p-4">
+
+<section class="my-4 p-4">
   <h2 class="text-xl font-bold">Secure Envelopes ({{ .EnvelopeCount }})</h2>
-  <div class="my-4" hx-get="/v1/transactions/{{ .ID }}/secure-envelopes" hx-trigger="load" hx-swap="beforeend">
+  <div class="my-4" hx-get="/v1/transactions/{{ .ID }}/secure-envelopes" hx-trigger="load">
     <div class="text-center">
       <span class="loading loading-spinner loading-lg"></span>
     </div>

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -111,6 +111,8 @@
         {{ if .LastUpdate }}
         {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 15:04:05" }}
         <td class="trans-last-update">{{ $lastUpdate }}</td>
+        <!-- Place last update in hidden input for debugging. -->
+        <input type="hidden" value="{{ $lastUpdate }}" />
         {{ else }}
         <td>&mdash;</td>
         {{ end }}

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -23,18 +23,18 @@
           {{ if eq .Source "local" }}
           <div class="tooltip tooltip-right" data-tip="Outgoing transaction from local VASP">
             <button>
-              <i class="fa-solid fa-file-export" title="Outgoing transaction from local VASP"></i>
+              <i class="fa-solid fa-file-export"></i>
             </button>
           </div>
           {{ else if eq .Source "remote" }}
          <div class="tooltip tooltip-right" data-tip="Incoming transaction from remote VASP">
           <button>
-            <i class="fa-solid fa-file-import" title="Incoming transaction from remote VASP"></i>
+            <i class="fa-solid fa-file-import"></i>
           </button>
          </div>
           {{ else }}
           <div class="tooltip tooltip-right" data-tip="Unknown transaction type">
-            <button><i class="fa-solid fa-question" title="Unknown transaction type"></i></button>
+            <button><i class="fa-solid fa-question"></i></button>
           </div>
           {{ end }}
         </td>
@@ -43,35 +43,35 @@
           <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/draftStatusIcon.svg" alt="" />
-              <span class="text-gray-500">{{ .Status }}</span>
+              <span class="text-gray-500">{{ .TitleStatus }}</span>
             </div>
           </td>
           {{ else if eq .Status "pending" }}
           <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/pendingStatusIcon.svg" alt="" />
-              <span class="text-yellow-700">{{ .Status }}</span>
+              <span class="text-yellow-700">{{ .TitleStatus }}</span>
             </div>
           </td>
           {{ else if eq .Status "action required" }}
           <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/actionStatusIcon.svg" alt="" />
-              <span class="text-blue-700">{{ .Status }}</span>
+              <span class="text-blue-700">{{ .TitleStatus }}</span>
             </div>
           </td>
           {{ else if eq .Status "completed" }}
           <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/completeStatusIcon.svg" alt="" />
-              <span class="text-green-700">{{ .Status }}</span>
+              <span class="text-green-700">{{ .TitleStatus }}</span>
             </div>
           </td>
           {{ else if eq .Status "archived" }}
           <td>
             <div class="flex justify-center items-center gap-x-1">
               <img src="/static/archiveStatusIcon.svg" alt="" />
-              <span class="text-gray-700">{{ .Status }}</span>
+              <span class="text-gray-700">{{ .TitleStatus }}</span>
             </div>
           </td>
           {{ else }}

--- a/pkg/web/templates/transactions_info.html
+++ b/pkg/web/templates/transactions_info.html
@@ -10,11 +10,6 @@
 
   <div class="divider"></div>
 
-  <section hx-get="/v1/transactions/{{ .ID }}/secure-envelopes" hx-trigger="load">
-    <div class="text-center">
-      <span class="loading loading-spinner loading-lg"></span>
-    </div>
-  </section>
 </section>
 
 <!-- Reject transaction modal -->

--- a/pkg/web/templates/transactions_info.html
+++ b/pkg/web/templates/transactions_info.html
@@ -7,9 +7,6 @@
       <span class="loading loading-spinner loading-lg"></span>
     </div>
   </section>
-
-  <div class="divider"></div>
-
 </section>
 
 <!-- Reject transaction modal -->


### PR DESCRIPTION
### Scope of changes

- Adds border around transaction detail info to visually separate content from secure envelope list.
- Adjusts the content displayed in the secure envelope list section.
- Removes duplicate tooltip from icons.
- Displays `Status` in title case in transaction list table.

[Figma](https://www.figma.com/design/4tlWXkkuC2xWRp5VSbRsHC/TRISA-Envoy?node-id=12048-1104&t=n3pRF3I6LLOda2Lb-4)

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Note: The image displays the page without any secure envelopes as they couldn't be created in development while making these changes.

https://tinyurl.com/26w9t2zo

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


