### PR TITLE
Remove envelope from template strings

### DIFF
--- a/pkg/web/templates/partials/transaction/transaction_accept.html
+++ b/pkg/web/templates/partials/transaction/transaction_accept.html
@@ -1,39 +1,38 @@
 <section class="my-4">
-  {{ if .Envelope }}
   <section>
     <div class="mb-4 md:mb-0">
-      <span class="font-semibold">Transaction ID: {{ .Envelope.Transaction.Txid }}</span>
+      <span class="font-semibold">Transaction ID: {{ .Transaction.Txid }}</span>
     </div>
   </section>
-  <form id="transaction-accept" hx-post="/v1/transactions/{{ .Envelope.Transaction.Txid }}/send" hx-swap="none"
+  <form id="transaction-accept" hx-post="/v1/transactions/{{ .Transaction.Txid }}/send" hx-swap="none"
     method="post">
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">1. TRANSACTION DETAILS</h2>
       <div class="grid gap-6 my-4 md:grid-cols-2">
         <div>
           <label for="originator" class="label-style">Originator Address</label>
-          <input type="text" id="originator" name="originator" value="{{ .Envelope.Transaction.Originator }}"
+          <input type="text" id="originator" name="originator" value="{{ .Transaction.Originator }}"
             class="input-style" />
         </div>
         <div>
           <label for="beneficiary" class="label-style">Beneficiary Address</label>
-          <input type="text" id="beneficiary" name="beneficiary" value="{{ .Envelope.Transaction.Beneficiary }}"
+          <input type="text" id="beneficiary" name="beneficiary" value="{{ .Transaction.Beneficiary }}"
             class="input-style" />
         </div>
         <!-- TODO: Replace input with select -->
         <div>
           <label for="network" class="label-style">Network</label>
-          <input type="text" id="network" name="network" value="{{ .Envelope.Transaction.Network }}" />
+          <input type="text" id="network" name="network" value="{{ .Transaction.Network }}" />
         </div>
         <div>
           <label for="amount" class="label-style">Amount</label>
-          <input id="amount" name="amount" value="{{ .Envelope.Transaction.Amount }}" class="input-style" />
+          <input id="amount" name="amount" value="{{ .Transaction.Amount }}" class="input-style" />
         </div>
       </div>
     </section>
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">2. ORIGINATOR DETAILS</h2>
-      {{ $originator := (index .Envelope.Identity.Originator.OriginatorPersons 0).Person.NaturalPerson }}
+      {{ $originator := (index .Identity.Originator.OriginatorPersons 0).Person.NaturalPerson }}
       {{ $originatorName := $originator.Name.NameIdentifiers }}
       {{ $originatorAddress := $originator.GeographicAddresses }}
       <div class="grid gap-6 my-4 md:grid-cols-2">
@@ -103,7 +102,7 @@
             value="{{ $originator.CustomerIdentification }}" class="input-style" />
         </div>
 
-        {{ range .Envelope.Identity.Originator.AccountNumbers }}
+        {{ range .Identity.Originator.AccountNumbers }}
         <div>
           <label for="orig_account_numbers" class="label-style">Account Number</label>
           <input type="text" id="orig_account_numbers" name="orig_account_numbers" value="{{ . }}"
@@ -114,7 +113,7 @@
     </section>
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">3. BENEFICIARY DETAILS </h2>
-      {{ $beneficiary := (index .Envelope.Identity.Beneficiary.BeneficiaryPersons 0).Person.NaturalPerson }}
+      {{ $beneficiary := (index .Identity.Beneficiary.BeneficiaryPersons 0).Person.NaturalPerson }}
       {{ $beneficiaryName := $beneficiary.Name.NameIdentifiers }}
       {{ $beneficiaryAddress := $beneficiary.GeographicAddresses }}
       <div class="grid gap-6 my-4 md:grid-cols-2">
@@ -184,7 +183,7 @@
             value="{{ $beneficiary.CustomerIdentification }}" class="input-style" />
         </div>
 
-        {{ range .Envelope.Identity.Beneficiary.AccountNumbers }}
+        {{ range .Identity.Beneficiary.AccountNumbers }}
         <div>
           <label for="benf_account_numbers" class="label-style">Account Number</label>
           <input type="text" id="benf_account_numbers" name="benf_account_numbers" value="{{ . }}"
@@ -196,7 +195,7 @@
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">4. ORIGINATING VASP DETAILS </h2>
       <div class="grid gap-6 my-4 md:grid-cols-2">
-        {{ $originatingVasp := .Envelope.Identity.OriginatingVasp.OriginatingVasp.Person.LegalPerson }}
+        {{ $originatingVasp := .Identity.OriginatingVasp.OriginatingVasp.Person.LegalPerson }}
         {{ $originatingLegalPerson := $originatingVasp.Name }}
 
         {{ range $originatingLegalPerson.NameIdentifiers }}
@@ -300,7 +299,7 @@
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">5. BENEFICIARY VASP DETAILS </h2>
       <div class="grid gap-6 my-4 md:grid-cols-2">
-        {{ $beneficiaryVasp := .Envelope.Identity.BeneficiaryVasp.BeneficiaryVasp.Person.LegalPerson }}
+        {{ $beneficiaryVasp := .Identity.BeneficiaryVasp.BeneficiaryVasp.Person.LegalPerson }}
 
         {{ range $beneficiaryVasp.NameIdentifiers }}
         <div>
@@ -388,9 +387,8 @@
     <div class="py-4 flex justify-center items-center gap-x-2">
       <button type="submit"
         class="p-1 rounded w-36 bg-green-700 font-semibold text-white md:p-2 hover:bg-green-700/80">Accept</button>
-      <a href="/transactions/{{ .Envelope.Transaction.Txid }}/info"
+      <a href="/transactions/{{ .Transaction.Txid }}/info"
         class="p-1 rounded w-36 bg-red-700 font-semibold text-white text-center md:p-2 hover:bg-red-700/80">Cancel</a>
     </div>
   </form>
-  {{ end }}
 </section>


### PR DESCRIPTION
### Scope of changes

This PR removes `.Envelope` from the template to resolve an issue preventing data from displaying on the transaction accept preview page.

Note: The form should display the latest secure envelope info. We currently aren't able to create a secure envelope in development, so this hasn't been completely tested yet.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


