### PR TITLE
Display N/A for empty values

### DIFF
--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2919,6 +2919,26 @@ html {
   padding-bottom: 2.25rem;
 }
 
+.px-12 {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.px-10 {
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+.px-20 {
+  padding-left: 5rem;
+  padding-right: 5rem;
+}
+
+.px-9 {
+  padding-left: 2.25rem;
+  padding-right: 2.25rem;
+}
+
 .pb-2 {
   padding-bottom: 0.5rem;
 }

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2919,26 +2919,6 @@ html {
   padding-bottom: 2.25rem;
 }
 
-.px-12 {
-  padding-left: 3rem;
-  padding-right: 3rem;
-}
-
-.px-10 {
-  padding-left: 2.5rem;
-  padding-right: 2.5rem;
-}
-
-.px-20 {
-  padding-left: 5rem;
-  padding-right: 5rem;
-}
-
-.px-9 {
-  padding-left: 2.25rem;
-  padding-right: 2.25rem;
-}
-
 .pb-2 {
   padding-bottom: 0.5rem;
 }

--- a/pkg/web/templates/partials/transaction/transaction_preview.html
+++ b/pkg/web/templates/partials/transaction/transaction_preview.html
@@ -92,16 +92,22 @@
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Address</dt>
                 <div>
-                  {{ range .AddressLine }}
-                  <dd>{{ . }}</dd>
+                  {{ if index .AddressLine 0 }}
+                  <dd>{{ index .AddressLine 0 }}</dd>
+                  <dd>{{ index .AddressLine 1 }}</dd>
+                  <dd>{{ index .AddressLine 2 }}</dd>
+                  {{ else }}
+                  <dd>N/A</dd>
                   {{ end }}
                   <dd>{{ .Country }}</dd>
                 </div>
               </div>
+              {{ if index .AddressLine 0 }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Address Type</dt>
                 <dd class="identifier-type badge-style">{{ .AddressType }}</dd>
               </div>
+              {{ end }}
               {{ end }}
 
               <div class="transaction-preview-container">
@@ -153,17 +159,23 @@
                 <dt class="font-semibold">Address</dt>
                 {{ range $beneficiaryAddress }}
                 <div>
-                  {{ range .AddressLine }}
-                  <dd>{{ . }}</dd>
+                  {{ if index .AddressLine 0 }}
+                  <dd>{{ index .AddressLine 0 }}</dd>
+                  <dd>{{ index .AddressLine 1 }}</dd>
+                  <dd>{{ index .AddressLine 2 }}</dd>
+                  {{ else }}
+                  <dd>N/A</dd>
                   {{ end }}
                   <dd>{{ .Country }}</dd>
                 </div>
               </div>
+              {{ if index .AddressLine 0 }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Address Type</dt>
                 <dd class="identifier-type badge-style">{{ .AddressType }}</dd>
-                {{ end }}
               </div>
+              {{ end }}
+              {{ end }}
 
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Country of Residence</dt>
@@ -235,7 +247,7 @@
                 <dt class="font-semibold">Address</dt>
                 <div>
                   {{ range .AddressLine }}
-                  <dd>{{ . }}</dd>
+                  <dd id="orig-vasp-addr-line">{{ . }}</dd>
                   {{ end }}
                   <dd>{{ .Country }}</dd>
                 </div>
@@ -294,18 +306,23 @@
               {{ range $beneficiaryVasp.GeographicAddresses }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Address</dt>
+                {{ if or .BuildingNumber .StreetName }} 
                 <div>
                   <dd>{{ .BuildingNumber }} {{ .StreetName }}</dd>
                   <dd>{{ .PostCode }} {{ .TownName }}</dd>
                   <dd>{{ .Country }}</dd>
                 </div>
+                {{ else }}
+                <dd>N/A</dd>
+                {{ end }}
               </div>
-              <!-- TODO: If there isn't an address do not display the type. -->
+              {{ if or .BuildingNumber .StreetName }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Address Type</dt>
                 <dd class="identifier-type badge-style">{{ .AddressType }}</dd>
-                {{ end }}
               </div>
+              {{ end }}
+              {{ end }}
 
               {{ $beneficiaryNationalIdentifier := $beneficiaryVasp.NationalIdentification }}
               <div class="transaction-preview-container">

--- a/pkg/web/templates/partials/transaction/transaction_preview.html
+++ b/pkg/web/templates/partials/transaction/transaction_preview.html
@@ -39,25 +39,26 @@
             <div class="grid md:grid-cols-2">
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Originator</dt>
-                <dd>{{ .Transaction.Originator }}</dd>
+                <dd>{{ if .Transaction.Originator }} {{ .Transaction.Originator }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Beneficiary</dt>
-                <dd>{{ .Transaction.Beneficiary }}</dd>
+                <dd>{{ if .Transaction.Beneficiary }} {{ .Transaction.Beneficiary }} {{ else }} N/A {{ end }}</dd>
               </div>
             </div>
             <div class="grid md:grid-cols-2">
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Amount</dt>
-                <dd>{{ .Transaction.Amount }}</dd>
+                <dd>{{ if .Transaction.Amount }} {{ .Transaction.Amount }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Network</dt>
-                <dd>{{ .Transaction.Network }}</dd>
+                <dd>{{ if .Transaction.Network }} {{ .Transaction.Network }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Travel Address</dt>
-                <dd class="max-w-sm break-words">{{ .TravelAddress }}</dd>
+                <dd class="max-w-sm break-words">
+                  {{ if .TravelAddress }} {{ .TravelAddress }} {{ else }} N/A {{ end }}</dd>
               </div>
             </div>
           </dl>
@@ -74,13 +75,18 @@
               <div class="transaction-preview-container">
                 {{ range $originatorName }}
                 <dt class="font-semibold">Name Identifiers</dt>
-                <dd>{{ .SecondaryIdentifier }} {{ .PrimaryIdentifier }}</dd>
+                <dd>
+                  {{ if .SecondaryIdentifier }} {{ .SecondaryIdentifier }} {{ end }}
+                  {{ if .PrimaryIdentifier }} {{ .PrimaryIdentifier }} {{ else }} <span>N/A</span>{{ end }}
+                </dd>
               </div>
+              {{ if or .PrimaryIdentifier .SecondaryIdentifier }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Name Identifiers Type</dt>
                 <dd class="identifier-type badge-style">{{ .NameIdentifierType }}</dd>
-                {{ end }}
               </div>
+              {{ end }}
+              {{ end }}
 
               {{ range $originatorAddress }}
               <div class="transaction-preview-container">
@@ -100,18 +106,21 @@
 
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Country of Residence</dt>
-                <dd>{{ $originator.CountryOfResidence }}</dd>
+                <dd>{{ if $originator.CountryOfResidence }} {{ $originator.CountryOfResidence }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Customer Identification</dt>
-                <div>{{ $originator.CustomerIdentification }}</div>
+                <div>{{ if $originator.CustomerIdentification }} {{ $originator.CustomerIdentification }} {{ else }} N/A {{ end }}</div>
               </div>
 
-              <!-- TODO: Add length check to display number or numbers -->
               <div class="transaction-preview-container">
+                {{ if gt (len .Identity.Originator.AccountNumbers) 1 }}
+                <dt class="font-semibold">Account Numbers</dt>
+                {{ else }}
                 <dt class="font-semibold">Account Number</dt>
+                {{ end }}
                 {{ range .Identity.Originator.AccountNumbers }}
-                <div>{{ . }}</div>
+                <div>{{ if . }} {{ . }} {{ else }} N/A {{ end }}</div>
                 {{ end }}
               </div>
             </dl>
@@ -126,13 +135,18 @@
 
                 {{ range $beneficiaryName }}
                 <dt class="font-semibold">Name Identifiers</dt>
-                <dd>{{ .SecondaryIdentifier }} {{ .PrimaryIdentifier }}</dd>
+                <dd>
+                  {{ if .SecondaryIdentifier }} {{ .SecondaryIdentifier }} {{ end }} 
+                  {{ if .PrimaryIdentifier }} {{ .PrimaryIdentifier }} {{ else }} N/A {{ end }}
+                </dd>
               </div>
+              {{ if or .PrimaryIdentifier .SecondaryIdentifier }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Name Identifiers Type</dt>
                 <dd class="identifier-type badge-style badge-style">{{ .NameIdentifierType }}</dd>
-                {{ end }}
               </div>
+              {{ end }}
+              {{ end }}
 
               {{ $beneficiaryAddress := $beneficiary.GeographicAddresses }}
               <div class="transaction-preview-container">
@@ -153,13 +167,16 @@
 
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Country of Residence</dt>
-                <dd>{{ $beneficiary.CountryOfResidence }}</dd>
+                <dd>{{ if $beneficiary.CountryOfResidence }} {{ $beneficiary.CountryOfResidence }} {{ else }} N/A {{ end }} </dd>
               </div>
               <div class="transaction-preview-container">
-                <!-- TODO: Check length to display number or numbers-->
+                {{ if gt (len .Identity.Beneficiary.AccountNumbers) 1 }}
+                <dt class="font-semibold">Account Numbers</dt>
+                {{ else }}
                 <dt class="font-semibold">Account Number</dt>
+                {{ end }}
                 {{ range .Identity.Beneficiary.AccountNumbers }}
-                <dd>{{ . }}</dd>
+                <dd>{{ if . }} {{ . }} {{ else }} N/A {{ end }}</dd>
                 {{ end }}
               </div>
 
@@ -177,34 +194,40 @@
               {{ range $originatingLegalPerson.NameIdentifiers }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Name Identifiers</dt>
-                <dd>{{ .LegalPersonName }}</dd>
+                <dd>{{ if .LegalPersonName }} {{ .LegalPersonName }} {{ else }} N/A {{ end }}</dd>
               </div>
+              {{ if .LegalPersonName }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Name Identifiers Type</dt>
                 <dd class="identifier-type badge-style">{{ .LegalPersonNameIdentifierType }}</dd>
               </div>
               {{ end }}
+              {{ end }}
 
               {{ range $originatingLegalPerson.LocalNameIdentifiers }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Local Name Identifiers</dt>
-                <dd>{{ .LegalPersonName }}</dd>
+                <dd>{{ if .LegalPersonName }} {{ .LegalPersonName }} {{ else }} N/A {{ end }}</dd>
               </div>
+              {{ if .LegalPersonName }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Local Name Identifiers Type</dt>
                 <dd class="identifier-type badge-style">{{ .LegalPersonNameIdentifierType }}</dd>
               </div>
               {{ end }}
+              {{ end }}
 
               {{ range $originatingLegalPerson.PhoneticNameIdentifiers }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Phonetic Name Identifiers</dt>
-                <dd>{{ .LegalPersonName }}</dd>
+                <dd>{{ if .LegalPersonName }} {{ .LegalPersonName }} {{ else }} N/A {{ end }}</dd>
               </div>
+              {{ if .LegalPersonName }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Phonetic Name Identifiers Type</dt>
                 <dd class="identifier-type badge-style">{{ .LegalPersonNameIdentifierType }}</dd>
               </div>
+              {{ end }}
               {{ end }}
 
               <div class="transaction-preview-container">
@@ -228,7 +251,7 @@
               {{ $nationalIdentification := $originatingVasp.NationalIdentification }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">National Identification</dt>
-                <dd>{{ $nationalIdentification.NationalIdentifier }}</dd>
+                <dd>{{ if $nationalIdentification.NationalIdentifier }} {{ $nationalIdentification.NationalIdentifier }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">National Identification Type</dt>
@@ -236,15 +259,15 @@
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Country of Issue</dt>
-                <dd>{{ $nationalIdentification.CountryOfIssue }}</dd>
+                <dd>{{ if $nationalIdentification.CountryOfIssue }} {{ $nationalIdentification.CountryOfIssue }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Registration Authority</dt>
-                <dd>{{ $nationalIdentification.RegistrationAuthority }}</dd>
+                <dd>{{ if $nationalIdentification.RegistrationAuthority }} {{ $nationalIdentification.RegistrationAuthority }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Country of Registration</dt>
-                <dd>{{ $originatingVasp.CountryOfRegistration }}</dd>
+                <dd>{{ if $originatingVasp.CountryOfRegistration }} {{ $originatingVasp.CountryOfRegistration }} {{ else }} N/A {{ end }}</dd>
               </div>
 
             </dl>
@@ -258,12 +281,14 @@
               {{ range $beneficiaryVasp.Name.NameIdentifiers }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Name Identifiers</dt>
-                <dd>{{ .LegalPersonName }}</dd>
+                <dd>{{ if .LegalPersonName }} {{ .LegalPersonName }} {{ else }} N/A {{ end }}</dd>
               </div>
+              {{ if .LegalPersonName }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Name Identifiers Type</dt>
                 <dd class="identifier-type badge-style">{{ .LegalPersonNameIdentifierType }}</dd>
               </div>
+              {{ end }}
               {{ end }}
 
               {{ range $beneficiaryVasp.GeographicAddresses }}
@@ -275,6 +300,7 @@
                   <dd>{{ .Country }}</dd>
                 </div>
               </div>
+              <!-- TODO: If there isn't an address do not display the type. -->
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Address Type</dt>
                 <dd class="identifier-type badge-style">{{ .AddressType }}</dd>
@@ -284,7 +310,7 @@
               {{ $beneficiaryNationalIdentifier := $beneficiaryVasp.NationalIdentification }}
               <div class="transaction-preview-container">
                 <dt class="font-semibold">National Identification</dt>
-                <dd>{{ $beneficiaryNationalIdentifier.NationalIdentifier }}</dd>
+                <dd>{{ if $beneficiaryNationalIdentifier.NationalIdentifier }} {{ $beneficiaryNationalIdentifier.NationalIdentifier }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">National Identification Type</dt>
@@ -292,15 +318,15 @@
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Country of Issue</dt>
-                <dd>{{ $beneficiaryNationalIdentifier.CountryOfIssue }}</dd>
+                <dd>{{ if $beneficiaryNationalIdentifier.CountryOfIssue }} {{ $beneficiaryNationalIdentifier.CountryOfIssue }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Registration Authority</dt>
-                <dd>{{ $beneficiaryNationalIdentifier.RegistrationAuthority }}</dd>
+                <dd>{{ if $beneficiaryNationalIdentifier.RegistrationAuthority }} {{ $beneficiaryNationalIdentifier.RegistrationAuthority }} {{ else }} N/A {{ end }}</dd>
               </div>
               <div class="transaction-preview-container">
                 <dt class="font-semibold">Country of Registration</dt>
-                <dd>{{ $beneficiaryVasp.CountryOfRegistration }}</dd>
+                <dd>{{ if $beneficiaryVasp.CountryOfRegistration }} {{ $beneficiaryVasp.CountryOfRegistration }} {{ else }} N/A {{ end }}</dd>
               </div>
 
             </dl>


### PR DESCRIPTION
### Scope of changes

This PR updates the transaction preview modal to display `N/A` when a value is empty. If an identifier value is `N/A` the corresponding identifier type is not displayed in the modal.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/28328851?key=9286c28d5a5c53f22c1318f9716b53df

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


