### PR TITLE
Display last update timestamp in local time

### DIFF
--- a/pkg/web/api/v1/transaction.go
+++ b/pkg/web/api/v1/transaction.go
@@ -213,6 +213,15 @@ func (c *Transaction) TitleStatus() string {
 	return cases.Title(language.English).String(c.Status)
 }
 
+// Convert last update timestamp to local time.
+func (c *Transaction) LocalizeLastUpdate() time.Time {
+	if c.LastUpdate != nil {
+		return c.LastUpdate.In(time.Local)
+	}
+
+	return time.Time{}
+}
+
 //===========================================================================
 // SecureEnvelopes
 //===========================================================================

--- a/pkg/web/api/v1/transaction.go
+++ b/pkg/web/api/v1/transaction.go
@@ -213,15 +213,6 @@ func (c *Transaction) TitleStatus() string {
 	return cases.Title(language.English).String(c.Status)
 }
 
-// Convert last update timestamp to local time.
-func (c *Transaction) LocalizeLastUpdate() time.Time {
-	if c.LastUpdate != nil {
-		return c.LastUpdate.In(time.Local)
-	}
-
-	return time.Time{}
-}
-
 //===========================================================================
 // SecureEnvelopes
 //===========================================================================

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -109,10 +109,8 @@
         {{ $created := .Created.Format "January 2, 2006 15:04:05" }}
         <td>{{ $created }}</td>
         {{ if .LastUpdate }}
-        {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 15:04:05" }}
+        {{ $lastUpdate := .LocalizeLastUpdate.Format "January 2, 2006 15:04:05" }}
         <td class="trans-last-update">{{ $lastUpdate }}</td>
-        <!-- Place last update in hidden input for debugging. -->
-        <input type="hidden" value="{{ $lastUpdate }}" />
         {{ else }}
         <td>&mdash;</td>
         {{ end }}

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -109,7 +109,7 @@
         {{ $created := .Created.Format "January 2, 2006 15:04:05" }}
         <td>{{ $created }}</td>
         {{ if .LastUpdate }}
-        {{ $lastUpdate := .LocalizeLastUpdate.Format "January 2, 2006 15:04:05" }}
+        {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 15:04:05 -0700" }}
         <td class="trans-last-update">{{ $lastUpdate }}</td>
         {{ else }}
         <td>&mdash;</td>


### PR DESCRIPTION
### Scope of changes

This creates a method to localize the `LastUpdate` timestamp as it is currently stored in UTC.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

The 1st envelope to appear in the table shown in the image was created at 6:05 PM ET.
https://tinyurl.com/2yphxrxz

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


