### PR TITLE
Fix bug duplicating network IDs when wallets are deleted

### DIFF
--- a/pkg/web/static/js/customerAccounts.js
+++ b/pkg/web/static/js/customerAccounts.js
@@ -42,8 +42,8 @@ document.body.addEventListener("htmx:configRequest", (e) => {
   }
 });
 
-// Count the number of wallet addresses to ensure a unique number as crypto wallets or added and deleted.
-// Start the counter at 1 to avoid a conflict with the first crypto wallet.
+// Count number of wallet addresses to create a unique ID as crypto wallets are added and deleted.
+// Start counter at 1 to avoid conflict with the first crypto wallet.
 let walletIdCounter = 1;
 
 // Add a new wallet address and network field to the new customer account form modal on click.
@@ -81,13 +81,13 @@ addWalletBttn?.addEventListener('click', () => {
       }
     });
 
-    // Get the selected network value for each additional wallet and set it as the selected value
-    // to ensure the dropdown does not reset the value when a new wallet is added.
-    const selectedValue = network?.value
+    // Get selected network for each additional wallet and set value to ensure the dropdown 
+    // does not reset to the default when wallets are added.
+    const selectedNetwork = network?.value
 
-    // Add network options to each additional wallet.
+    // Set network options and value for each wallet.
     network?.slim?.setData(networksArray);
-    network?.slim?.setSelected(selectedValue);
+    network?.slim?.setSelected(selectedNetwork);
   })
 })
 

--- a/pkg/web/static/js/customerAccounts.js
+++ b/pkg/web/static/js/customerAccounts.js
@@ -42,9 +42,13 @@ document.body.addEventListener("htmx:configRequest", (e) => {
   }
 });
 
+// Count the number of wallet addresses to ensure a unique number as crypto wallets or added and deleted.
+// Start the counter at 1 to avoid a conflict with the first crypto wallet.
+let walletIdCounter = 1;
+
 // Add a new wallet address and network field to the new customer account form modal on click.
 addWalletBttn?.addEventListener('click', () => {
-  const walletCount = walletDiv?.children.length * 1
+  const walletCount = walletIdCounter;
   walletDiv?.insertAdjacentHTML('beforeend', `
   <div class="grid gap-6 my-4 md:grid-cols-2 crypto-wallets">
     <div>
@@ -54,29 +58,37 @@ addWalletBttn?.addEventListener('click', () => {
     <div>
       <label for="network_${walletCount}" class="label-style">Network</label>
       <div class="flex items-center gap-x-1">
-        <select id="network_${walletCount}" name="network_${walletCount}"></select>
+        <select id="network_${walletCount}" name="network_${walletCount}" class="acct-networks"></select>
         <button type="button" onclick="this.parentNode.parentNode.parentNode.remove()" class="tooltip tooltip-left" data-tip="Delete wallet">
           <i class="fa-solid fa-trash text-xs"><span class="sr-only">Delete wallet</span></i>
         </button>
       </div>
     </div>
   </div>
-  `)
+  `);
 
-  // TODO: Does a new div need to be created for each network select?
-  // Create a div to ensure content appears in the modal and not the document body.
-  newAcctModal.appendChild(document.createElement('div')).id = `network_list_${walletCount}`
+  // Increment the wallet counter for the next wallet address.
+  walletIdCounter++;
 
-  // Initialize network select for each new wallet.
-  const additionalNetworkSelect = new SlimSelect({
-    select: `#network_${walletCount}`,
-    settings: {
-      contentLocation: document.getElementById(`network_list_${walletCount}`),
-    },
+  // Create a searchable select dropdown for the network when a new wallet is added.
+  const acctNetworks = document.querySelectorAll('.acct-networks')
+  // Initialize SlimSelect for each crypto wallet network.
+  acctNetworks.forEach((network) => {
+    new SlimSelect({
+      select: network,
+      settings: {
+        contentLocation: document.getElementById('new_acct_modal')
+      }
+    });
+
+    // Get the selected network value for each additional wallet and set it as the selected value
+    // to ensure the dropdown does not reset the value when a new wallet is added.
+    const selectedValue = network?.value
+
+    // Add network options to each additional wallet.
+    network?.slim?.setData(networksArray);
+    network?.slim?.setSelected(selectedValue);
   })
-
-  // Add network options to additional wallet.
-  additionalNetworkSelect.setData(networksArray);
 })
 
 // Close the new customer account modal and reset the form values on success.
@@ -113,11 +125,11 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
       });
 
       // Get each network value selected by the requester from the hidden input field.
-      const networkID = network.id;
+      const networkID = network?.id;
       const selectedNetwork = document.querySelector(`.${networkID}`);
 
       if (selectedNetwork) {
-        const networkValue = selectedNetwork.value;
+        const networkValue = selectedNetwork?.value;
         setNetworkData(network, networkValue);
       };
     });
@@ -127,6 +139,6 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
 // Set the network options and selected value in a SlimSelect dropdown for each network.
 function setNetworkData(el, value) {
   // Add network options to the select element.
-  el.slim.setData(networksArray);
-  el.slim.setSelected(value);
+  el?.slim?.setData(networksArray);
+  el?.slim?.setSelected(value);
 }


### PR DESCRIPTION
### Scope of changes

This PR resolves a bug that caused IDs assigned to additional crypto wallet network elements to duplicate if a wallet was deleted out of sequential order.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/28830133?key=56e6e5838312f2e6eade6933ceb29ad1

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


