### PR TITLE
Humanize last update on transaction detail page, localize envelope timestamp with offset

### DIFF
--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -35,8 +35,8 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
     if (e.detail.requestConfig.path === `/v1/transactions/${transactionID}/secure-envelopes` && e.detail.requestConfig.verb === 'get') {
       const envelopeTimestamp = document.querySelectorAll('.envelope-timestamp');
       envelopeTimestamp.forEach((timestamp) => {
-        const localTime = dayjs(timestamp.textContent)
-        timestamp.textContent = localTime?.$d
+        const localTime = dayjs(timestamp.textContent).format('MMM DD, YYYY hh:mm:ss')
+        timestamp.textContent = localTime
       })
     }
 });

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -31,14 +31,14 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
     lastUpdate.textContent = humanizeLastUpdate;
   }
 
-    // Display envelope timestamp in local time.
-    if (e.detail.requestConfig.path === `/v1/transactions/${transactionID}/secure-envelopes` && e.detail.requestConfig.verb === 'get') {
-      const envelopeTimestamp = document.querySelectorAll('.envelope-timestamp');
-      envelopeTimestamp.forEach((timestamp) => {
-        const localTime = dayjs(timestamp.textContent).format('MMM DD, YYYY hh:mm:ss A')
-        timestamp.textContent = localTime
-      })
-    }
+  // Display envelope timestamp in local time.
+  if (e.detail.requestConfig.path === `/v1/transactions/${transactionID}/secure-envelopes` && e.detail.requestConfig.verb === 'get') {
+    const envelopeTimestamp = document.querySelectorAll('.envelope-timestamp');
+    envelopeTimestamp.forEach((timestamp) => {
+      const localTime = dayjs(timestamp.textContent).format('MMM DD, YYYY hh:mm:ss A')
+      timestamp.textContent = localTime
+    })
+  }
 });
 
 // Add code to amend the request parameters before the request is sent.

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -1,6 +1,5 @@
 const transactionID = document.getElementById('transaction-id');
 
-
 // Add code to run after HTMX settles the DOM once a swap occurs.
 document.body.addEventListener('htmx:afterSettle', (e) => {
   const envelopeListEP = `/v1/transactions/${transactionID?.value}/secure-envelopes`
@@ -22,6 +21,13 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
     });
 
     // TODO: Add code to toggle show/hide for PKS.
+  }
+
+  // Humanize the last update timestamp.
+  if (e.detail.requestConfig.path === `/v1/transactions/${transactionID?.value}?detail=full` && e.detail.requestConfig.verb === 'get') {
+    const lastUpdate = document.querySelector('.trans-last-update');
+    const humanizeLastUpdate = dayjs(lastUpdate.textContent).fromNow();
+    lastUpdate.textContent = humanizeLastUpdate;
   }
 });
 

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -1,8 +1,9 @@
-const transactionID = document.getElementById('transaction-id');
+const transactionEl = document.getElementById('transaction-id');
+const transactionID = transactionEl?.value
 
 // Add code to run after HTMX settles the DOM once a swap occurs.
 document.body.addEventListener('htmx:afterSettle', (e) => {
-  const envelopeListEP = `/v1/transactions/${transactionID?.value}/secure-envelopes`
+  const envelopeListEP = `/v1/transactions/${transactionID}/secure-envelopes`
   if (e.detail.requestConfig.path === envelopeListEP && e.detail.requestConfig.verb === 'get') {
     // Toggle the collapse-close class when an accordion is clicked.
     document.querySelectorAll('.envelope-accordion').forEach((accordion) => {
@@ -24,15 +25,15 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
   }
 
   // Humanize the last update timestamp.
-  if (e.detail.requestConfig.path === `/v1/transactions/${transactionID?.value}?detail=full` && e.detail.requestConfig.verb === 'get') {
+  if (e.detail.requestConfig.path === `/v1/transactions/${transactionID}?detail=full` && e.detail.requestConfig.verb === 'get') {
     const lastUpdate = document.querySelector('.trans-last-update');
     const humanizeLastUpdate = dayjs(lastUpdate.textContent).fromNow();
     lastUpdate.textContent = humanizeLastUpdate;
   }
 
     // Display envelope timestamp in local time.
-    if (e.detail.requestConfig.path === `/v1/transactions/${transactionID?.value}/secure-envelopes` && e.detail.requestConfig.verb === 'get') {
-      const envelopeTimestamp = document.querySelectorAll('.env-timestamp');
+    if (e.detail.requestConfig.path === `/v1/transactions/${transactionID}/secure-envelopes` && e.detail.requestConfig.verb === 'get') {
+      const envelopeTimestamp = document.querySelectorAll('.envelope-timestamp');
       envelopeTimestamp.forEach((timestamp) => {
         const localTime = dayjs(timestamp.textContent)
         timestamp.textContent = localTime?.$d
@@ -41,8 +42,7 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
 });
 
 // Add code to amend the request parameters before the request is sent.
-const rejectEP = `/v1/transactions/${transactionID?.value}/reject`
-
+const rejectEP = `/v1/transactions/${transactionID}/reject`
 document.body.addEventListener('htmx:configRequest', (e) => {
   // Determine if the request repair checkbox is checked and add to the request parameters.
   const isRetryChecked = document.getElementById('request_retry')

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -35,7 +35,7 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
     if (e.detail.requestConfig.path === `/v1/transactions/${transactionID}/secure-envelopes` && e.detail.requestConfig.verb === 'get') {
       const envelopeTimestamp = document.querySelectorAll('.envelope-timestamp');
       envelopeTimestamp.forEach((timestamp) => {
-        const localTime = dayjs(timestamp.textContent).format('MMM DD, YYYY hh:mm:ss')
+        const localTime = dayjs(timestamp.textContent).format('MMM DD, YYYY hh:mm:ss A')
         timestamp.textContent = localTime
       })
     }

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -29,6 +29,15 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
     const humanizeLastUpdate = dayjs(lastUpdate.textContent).fromNow();
     lastUpdate.textContent = humanizeLastUpdate;
   }
+
+    // Display envelope timestamp in local time.
+    if (e.detail.requestConfig.path === `/v1/transactions/${transactionID?.value}/secure-envelopes` && e.detail.requestConfig.verb === 'get') {
+      const envelopeTimestamp = document.querySelectorAll('.env-timestamp');
+      envelopeTimestamp.forEach((timestamp) => {
+        const localTime = dayjs(timestamp.textContent)
+        timestamp.textContent = localTime?.$d
+      })
+    }
 });
 
 // Add code to amend the request parameters before the request is sent.

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -1357,11 +1357,6 @@ html {
   background-color: var(--fallback-b1,oklch(var(--b1)/var(--tw-bg-opacity)));
 }
 
-.table-zebra tbody tr:nth-child(even) :where(.table-pin-cols tr th) {
-  --tw-bg-opacity: 1;
-  background-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-bg-opacity)));
-}
-
 .textarea {
   min-height: 3rem;
   flex-shrink: 1;
@@ -2250,13 +2245,6 @@ details.collapse summary::-webkit-details-marker {
   background-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-bg-opacity)));
 }
 
-.table-zebra tr.active,
-    .table-zebra tr.active:nth-child(even),
-    .table-zebra-zebra tbody tr:nth-child(even) {
-  --tw-bg-opacity: 1;
-  background-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-bg-opacity)));
-}
-
 .table :where(thead, tbody) :where(tr:not(:last-child)),
     .table :where(thead, tbody) :where(tr:first-child:last-child) {
   border-bottom-width: 1px;
@@ -3078,11 +3066,6 @@ details.collapse summary::-webkit-details-marker {
 .bg-gray-700 {
   --tw-bg-opacity: 1;
   background-color: rgb(55 65 81 / var(--tw-bg-opacity));
-}
-
-.bg-green-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
 }
 
 .bg-green-700 {

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -67,8 +67,8 @@
     {{ if .IsError }}
     <div class="collapse-title bg-red-200 text-xl font-medium">
       {{ else }}
-      <div class="collapse-title bg-green-200 text-xl font-medium">
-        {{ end }}
+    <div class="collapse-title text-xl font-medium">
+      {{ end }}
         <h3 class="font-semibold text-lg">ID: {{ .ID }}</h3>
       </div>
       <div class="collapse-content">
@@ -77,8 +77,8 @@
           <dl class="mt-2">
             <div class="py-1 grid grid-cols-2">
               <dt>Envelope Timestamp</dt>
-              {{ $timestamp := .Timestamp.Format "January 2, 2006 15:04:05" }}
-              <dd>{{ $timestamp }}</dd>
+              {{ $timestamp := .Timestamp.Format "January 2, 2006 15:04:05 -0700" }}
+              <dd class="env-timestamp">{{ $timestamp }}</dd>
             </div>
             <div class="py-1 grid grid-cols-2">
               <dt>Status</dt>

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -78,7 +78,7 @@
             <div class="py-1 grid grid-cols-2">
               <dt>Envelope Timestamp</dt>
               {{ $timestamp := .Timestamp.Format "January 2, 2006 15:04:05 -0700" }}
-              <dd class="env-timestamp">{{ $timestamp }}</dd>
+              <dd class="envelope-timestamp">{{ $timestamp }}</dd>
             </div>
             <div class="py-1 grid grid-cols-2">
               <dt>Status</dt>

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -63,7 +63,7 @@
           <dd class="font-bold">Last Update</dd>
           {{ if .LastUpdate }}
           {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 15:04:05 -0700" }}
-          <dt class="trans-last-update">{{ .LastUpdate }}</dt>
+          <dt class="trans-last-update">{{ $lastUpdate }}</dt>
           {{ else }}
           <dt>N/A</dt>
           {{ end }}

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -62,8 +62,8 @@
         <div class="grid grid-cols-2 p-2">
           <dd class="font-bold">Last Update</dd>
           {{ if .LastUpdate }}
-          {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 3:04:05 PM" }}
-          <dt>{{ $lastUpdate }}</dt>
+          {{ $lastUpdate := .LastUpdate.Format "January 2, 2006 15:04:05 -0700" }}
+          <dt class="trans-last-update">{{ .LastUpdate }}</dt>
           {{ else }}
           <dt>N/A</dt>
           {{ end }}

--- a/pkg/web/templates/transactions_info.html
+++ b/pkg/web/templates/transactions_info.html
@@ -15,5 +15,8 @@
 {{ end }}
 
 {{ define "appcode" }}
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/plugin/relativeTime.js"></script>
+<script>dayjs.extend(window.dayjs_plugin_relativeTime)</script>
 <script src="/static/js/transactionInfo.js"></script>
 {{ end }}


### PR DESCRIPTION
### Scope of changes

This PR updates the timestamps on the transaction detail page. The last update timestamp is now humanized to appear like it does on the transaction list page. The envelope timestamp has also been amended to display in local time by adding an offset and using `dayjs` for formatting. 

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

https://tinyurl.com/2k76b4x8

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


