### PR TITLE
Display send envelope and export transactions button to users with appropriate permission

### DIFF
--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -931,6 +931,16 @@ html {
     opacity: 1;
   }
 
+  .btm-nav > *.disabled:hover,
+      .btm-nav > *[disabled]:hover {
+    pointer-events: none;
+    --tw-border-opacity: 0;
+    background-color: var(--fallback-n,oklch(var(--n)/var(--tw-bg-opacity)));
+    --tw-bg-opacity: 0.1;
+    color: var(--fallback-bc,oklch(var(--bc)/var(--tw-text-opacity)));
+    --tw-text-opacity: 0.2;
+  }
+
   .btn:hover {
     --tw-border-opacity: 1;
     border-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-border-opacity)));
@@ -1399,6 +1409,16 @@ html {
   color: var(--fallback-erc,oklch(var(--erc)/var(--tw-text-opacity)));
   --alert-bg: var(--fallback-er,oklch(var(--er)/1));
   --alert-bg-mix: var(--fallback-b1,oklch(var(--b1)/1));
+}
+
+.btm-nav > *.disabled,
+    .btm-nav > *[disabled] {
+  pointer-events: none;
+  --tw-border-opacity: 0;
+  background-color: var(--fallback-n,oklch(var(--n)/var(--tw-bg-opacity)));
+  --tw-bg-opacity: 0.1;
+  color: var(--fallback-bc,oklch(var(--bc)/var(--tw-text-opacity)));
+  --tw-text-opacity: 0.2;
 }
 
 .btm-nav > * .label {

--- a/pkg/web/templates/transactions.html
+++ b/pkg/web/templates/transactions.html
@@ -21,6 +21,7 @@
   </section>
   <section class="mb-12">
     <h1 class="font-bold text-2xl">Transaction Inbox</h1>
+    {{ if or (.HasRole "Admin") (.HasRole "Compliance") }}
     <div class="mt-6 flex justify-between items-center">
       <div class="flex items-center gap-x-1">
         <a href="/send-envelope" class="btn btn-sm bg-primary text-white hover:bg-primary/90">Send New Secure Envelope</a>
@@ -31,7 +32,8 @@
         </div>
       </div>
       <a href="/v1/transactions/export" download class="btn btn-sm bg-black text-white hover:bg-black/80">Export Transactions</a>
-    </div>  
+    </div>
+    {{ end }}  
   </section>
   <section id="transactions" hx-get="/v1/transactions" hx-ext="json-enc" hx-trigger="load">
     <div class="text-center">


### PR DESCRIPTION
### Scope of changes

This PR displays the `Send Secure Envelope` and `Export Transactions` buttons on the transactions page to users who have the ability to complete those actions.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/29359338?key=4109b607239fce1199309bf4be4bb5a4

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


