### PR TITLE
Prevent transaction list table from spilling outside container

### DIFF
--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2552,18 +2552,6 @@ details.collapse summary::-webkit-details-marker {
   border-bottom-left-radius: 0px;
 }
 
-.table-xs :not(thead):not(tfoot) tr {
-  font-size: 0.75rem;
-  line-height: 1rem;
-}
-
-.table-xs :where(th, td) {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-}
-
 .table-sm :not(thead):not(tfoot) tr {
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2564,6 +2564,18 @@ details.collapse summary::-webkit-details-marker {
   padding-bottom: 0.25rem;
 }
 
+.table-sm :not(thead):not(tfoot) tr {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.table-sm :where(th, td) {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
 .tooltip {
   position: relative;
   display: inline-block;

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2552,6 +2552,18 @@ details.collapse summary::-webkit-details-marker {
   border-bottom-left-radius: 0px;
 }
 
+.table-xs :not(thead):not(tfoot) tr {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.table-xs :where(th, td) {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
 .tooltip {
   position: relative;
   display: inline-block;
@@ -2667,10 +2679,6 @@ details.collapse summary::-webkit-details-marker {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
-}
-
-.visible {
-  visibility: visible;
 }
 
 .collapse {
@@ -3602,6 +3610,15 @@ body main {
 
 .htmx-request.htmx-indicator{
   display: inline;
+}
+
+/* Set a media query for the transaction list table */
+
+@media (max-width: 1536px) {
+  .table-container {
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
 }
 
 @media (min-width: 768px) {

--- a/pkg/web/static/styles/style.css
+++ b/pkg/web/static/styles/style.css
@@ -76,3 +76,11 @@ body main {
 .htmx-request.htmx-indicator{
   display: inline;
 }
+
+/* Set a media query for the transaction list table */
+@media (max-width: 1536px) {
+  .table-container {
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+}

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -1,5 +1,5 @@
-<div>
-  <table class="table">
+<div class="table-container">
+  <table class="table table-xs">
     <thead class="font-bold text-base text-black">
       <tr class="text-center text-balance">
         <th>Preview</th>
@@ -125,7 +125,7 @@
         <td>
           <div class="dropdown">
             <div tabindex="0" role="button" class="btn btn-ghost font-bold text-xl">&hellip;</div>
-            <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-black font-semibold text-white rounded-box">
+            <ul tabindex="0" class="dropdown-content z-[1] menu menu-sm p-2 text-sm shadow bg-black font-semibold text-white rounded-box">
               <li><a href="/transactions/{{ .ID }}/info">View</a></li>
               {{ if eq .Source "remote" }}
               <li><a href="/transactions/{{ .ID }}/accept">Accept</a></li>

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -1,5 +1,5 @@
 <div class="table-container">
-  <table class="table table-xs">
+  <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr class="text-center text-balance">
         <th>Preview</th>


### PR DESCRIPTION
### Scope of changes

This adds an overflow style to smaller screens so that scrollbars may appear and prevent the transaction list data from spilling outside its container.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/29436840?key=684d3e2f5036b4c6f1375d8387fddc95

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


