### PR TITLE
Display add/edit buttons to users with access, update table style

### DIFF
--- a/pkg/web/accounts.go
+++ b/pkg/web/accounts.go
@@ -145,6 +145,7 @@ func (s *Server) AccountDetail(c *gin.Context) {
 		Offered:  []string{binding.MIMEJSON, binding.MIMEHTML},
 		Data:     out,
 		HTMLName: "account_detail.html",
+		HTMLData: scene.New(c).WithAPIData(out),
 	})
 }
 

--- a/pkg/web/scene/scene.go
+++ b/pkg/web/scene/scene.go
@@ -120,6 +120,15 @@ func (s Scene) AccountsList() *api.AccountsList {
 	return nil
 }
 
+func (s Scene) AccountDetail() *api.Account {
+	if data, ok := s[APIData]; ok {
+		if out, ok := data.(*api.Account); ok {
+			return out
+		}
+	}
+	return nil
+}
+
 func (s Scene) UserList() *api.UserList {
 	if data, ok := s[APIData]; ok {
 		if out, ok := data.(*api.UserList); ok {

--- a/pkg/web/templates/accounts.html
+++ b/pkg/web/templates/accounts.html
@@ -3,7 +3,9 @@
   <section class="mx-8 py-14">
     <section class="md:flex md:items-center md:gap-x-6 mb-12">
       <h1 class="font-bold text-2xl">Customer Accounts</h1>
+      {{ if not .IsViewOnly }}
       <button type="button" onclick="new_acct_modal.showModal()" class="mt-3 md:mt-0 btn btn-sm bg-primary text-white hover:bg-primary/90">Register New Customer</button>
+      {{ end }}
     </section>
     <section id="accounts" hx-get="/v1/accounts" hx-trigger="load">
       <div class="text-center">

--- a/pkg/web/templates/counterparty.html
+++ b/pkg/web/templates/counterparty.html
@@ -3,7 +3,9 @@
   <section class="mx-8 py-14">
     <section class="flex gap-x-6 mb-12">
       <h1 class="font-bold text-2xl">Counterparty VASPs</h1>
+      {{ if not .IsViewOnly }}
       <button onclick="add_cparty_modal.showModal()" class="btn btn-sm bg-primary text-white hover:bg-primary/90">Add New VASP</button>
+      {{ end }}
     </section>
     <section id="counterparties" hx-get="/v1/counterparties" hx-trigger="load">
       <div class="text-center">

--- a/pkg/web/templates/partials/account/account_detail.html
+++ b/pkg/web/templates/partials/account/account_detail.html
@@ -1,3 +1,5 @@
+{{ $canEditAcct := not .IsViewOnly }}
+{{ with .AccountDetail }}
 <div class="modal-box max-w-3xl">
   <div class="mb-4 flex justify-between items-center">
     <h1 class="font-bold text-xl">Customer Details</h1>
@@ -38,7 +40,10 @@
   </dl>
   {{ end }}
   {{ end }}
+  {{ if $canEditAcct }}
   <div class="mt-8 flex justify-center">
     <button id="edit-acct-bttn" hx-get="/v1/accounts/{{ .ID }}/edit" hx-target="#acct_modal" hx-swap="innerHTML" class="w-44 btn bg-primary font-semibold text-lg text-white hover:bg-primary/90">Edit</button>
   </div>
+  {{ end }}
 </div>
+{{ end }}

--- a/pkg/web/templates/partials/account/account_list.html
+++ b/pkg/web/templates/partials/account/account_list.html
@@ -1,7 +1,7 @@
 {{ $canEditAccounts := not .IsViewOnly }}
 {{- with .AccountsList -}}
-<div>
-  <table class="table overflow-x-auto">
+<div class="table-container">
+  <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr>
         <th>Customer ID</th>

--- a/pkg/web/templates/partials/counterparty/counterparty_list.html
+++ b/pkg/web/templates/partials/counterparty/counterparty_list.html
@@ -1,7 +1,7 @@
 {{- $canEditAccounts := not .IsViewOnly -}}
 {{- with .CounterpartyList -}}
-<div>
-  <table class="table overflow-x-auto">
+<div class="table-container">
+  <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr>
         <th>Name</th>

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -62,7 +62,7 @@
 {{ if .SecureEnvelopes }}
 {{ range .SecureEnvelopes }}
 <div class="my-4">
-  <div class="envelope-accordion collapse collapse-close collapse-arrow bg-base-200">
+  <div class="envelope-accordion collapse collapse-close collapse-arrow bg-base-200 border-2 border-gray-300">
     <input type="radio" name="my-accordion-1" checked="checked" />
     {{ if .IsError }}
     <div class="collapse-title bg-red-200 text-xl font-medium">

--- a/pkg/web/templates/partials/user/user_list.html
+++ b/pkg/web/templates/partials/user/user_list.html
@@ -1,7 +1,7 @@
 {{- $isAdmin := .IsAdmin -}}
 {{- with .UserList -}}
-<div>
-  <table class="table">
+<div class="table-container">
+  <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr>
         <th>Name</th>


### PR DESCRIPTION
### Scope of changes

- Makes add/edit account and counterparty buttons visible to users with the appropriate access.
- Sets `table-sm` class to account, counterparty, and users tables and adds `table-container` class to apply overflow style to tables to be consistent with the transactions table.
- Adds border around the secure envelope accordion component.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/29469160?key=a3355030b0d5e5d87464a1d495c86a79

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


