### PR TITLE
Remove offset from created timestamps

### DIFF
--- a/pkg/web/templates/partials/account/account_list.html
+++ b/pkg/web/templates/partials/account/account_list.html
@@ -22,7 +22,7 @@
           {{ else }}
           <td class="px-16">-</td>
           {{ end }}
-          {{ $created := .Created.Format "January 2, 2006 15:04:05 -0700" }}
+          {{ $created := .Created.Format "January 2, 2006 15:04:05" }}
           <td>{{ $created }}</td>
           <td>
             <div class="dropdown">

--- a/pkg/web/templates/partials/counterparty/counterparty_list.html
+++ b/pkg/web/templates/partials/counterparty/counterparty_list.html
@@ -20,7 +20,7 @@
         <td>{{ .Website }}</td>
         <td>{{ .Protocol }}</td>
         <td class="max-w-sm break-words">{{ .TravelAddress }}</td>
-        {{ $created := .Created.Format "January 2, 2006 15:04:05 -0700" }}
+        {{ $created := .Created.Format "January 2, 2006 15:04:05" }}
         <td>{{ $created }}</td>
         <td>
           <div class="dropdown">

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -77,7 +77,7 @@
           <dl class="mt-2">
             <div class="py-1 grid grid-cols-2">
               <dt>Envelope Timestamp</dt>
-              {{ $timestamp := .Timestamp.Format "January 2, 2006 15:04:05" }}
+              {{ $timestamp := .Timestamp.Format "January 2, 2006 15:04:05 -0700" }}
               <dd class="envelope-timestamp">{{ $timestamp }}</dd>
             </div>
             <div class="py-1 grid grid-cols-2">

--- a/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
+++ b/pkg/web/templates/partials/secure_envelope/secure_envelope_list.html
@@ -77,7 +77,7 @@
           <dl class="mt-2">
             <div class="py-1 grid grid-cols-2">
               <dt>Envelope Timestamp</dt>
-              {{ $timestamp := .Timestamp.Format "January 2, 2006 15:04:05 -0700" }}
+              {{ $timestamp := .Timestamp.Format "January 2, 2006 15:04:05" }}
               <dd class="envelope-timestamp">{{ $timestamp }}</dd>
             </div>
             <div class="py-1 grid grid-cols-2">

--- a/pkg/web/templates/partials/user/user_list.html
+++ b/pkg/web/templates/partials/user/user_list.html
@@ -21,10 +21,10 @@
         <td>{{ .Name }}</td>
         <td>{{ .Email }}</td>
         <td>{{ .Role }}</td>
-        {{ $created := .Created.Format "January 2, 2006 15:04:05 -0700" }}
+        {{ $created := .Created.Format "January 2, 2006 15:04:05" }}
         <td>{{ $created }}</td>
         {{ if .LastLogin }}
-        {{ $lastLogin := .LastLogin.Format "January 2, 2006 15:04:05 -0700" }}
+        {{ $lastLogin := .LastLogin.Format "January 2, 2006 15:04:05" }}
         <td>{{ $lastLogin }}</td>
         {{ else }}
         <td>&mdash;</td>


### PR DESCRIPTION
### Scope of changes

This PR removes an offset from created timestamps in the accounts, counterparty, and user tables. The offset was previously added for accounts and the secure envelope list and didn't result in `+0000` appearing, so changes weren't made there.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


