### PR TITLE
Add Envelope Decryption to API

### DIFF
--- a/pkg/store/sqlite/transactions.go
+++ b/pkg/store/sqlite/transactions.go
@@ -205,7 +205,7 @@ func (s *Store) LatestSecureEnvelope(ctx context.Context, envelopeID uuid.UUID, 
 // Secure Envelopes CRUD Interface
 //===========================================================================
 
-const listSecureEnvelopesSQL = "SELECT * FROM secure_envelopes WHERE envelope_id=:envelopeID"
+const listSecureEnvelopesSQL = "SELECT * FROM secure_envelopes WHERE envelope_id=:envelopeID ORDER BY timestamp DESC"
 
 func (s *Store) ListSecureEnvelopes(ctx context.Context, txID uuid.UUID, page *models.PageInfo) (out *models.SecureEnvelopePage, err error) {
 	var tx *sql.Tx

--- a/pkg/web/errors.go
+++ b/pkg/web/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrNoLocalCommonName = errors.New("invalid configuration: no common name in trisa endpoint configuration")
 	ErrNoLocalparty      = errors.New("could not lookup local vasp counterparty from database, please try again later")
 	ErrNotAccepted       = errors.New("the accepted formats are not offered by the server")
+	ErrNoPublicKey       = errors.New("no public key associated with secure envelope")
 )
 
 // Renders the "not found page"


### PR DESCRIPTION
### Scope of changes

Decrypts envelopes on request in SecureEnvelope List and Detail API handlers.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

There are a few things that still need to be taken care of, including adding the remote peer to the list return and using that common name in the lookup of the unsealing keys.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.
- [ ] The data returned in the API contains all required fields for the user interface