### PR TITLE
Fix typo in Transaction type

### DIFF
--- a/pkg/web/api/v1/transaction.go
+++ b/pkg/web/api/v1/transaction.go
@@ -38,7 +38,7 @@ type Transaction struct {
 	Counterparty       string     `json:"counterparty"`
 	CounterpartyID     ulid.ULID  `json:"counterparty_id,omitempty"`
 	Originator         string     `json:"originator,omitempty"`
-	OriginatorAddress  string     `json:"orginator_address,omitempty"`
+	OriginatorAddress  string     `json:"originator_address,omitempty"`
 	Beneficiary        string     `json:"beneficiary,omitempty"`
 	BeneficiaryAddress string     `json:"beneficiary_address,omitempty"`
 	VirtualAsset       string     `json:"virtual_asset"`


### PR DESCRIPTION
### Scope of changes

Hello team, I've noticed a typo on the transaction response while integrating the TRISA Node APIs. The `originator_address` was missing the letter `i` (was `orginator_address`). 

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

TRISA Node API endpoints that returns a `Transaction` object such as list transactions (GET `v1/transactions`) should show corrected field name (orginator_address -> originator_address).

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


