### PR TITLE
Use input event on password and confirm password

### DIFF
--- a/pkg/web/static/js/usersManagement.js
+++ b/pkg/web/static/js/usersManagement.js
@@ -53,7 +53,6 @@ document.addEventListener('htmx:afterSettle', (e) => {
       };
     };
 
-    // TODO: Should input also be included in the events lists?
     addEventListeners(passwordInput, 'input', checkPasswords);
     addEventListeners(confirmPassword, 'input', checkPasswords);
   };

--- a/pkg/web/static/js/usersManagement.js
+++ b/pkg/web/static/js/usersManagement.js
@@ -54,8 +54,8 @@ document.addEventListener('htmx:afterSettle', (e) => {
     };
 
     // TODO: Should input also be included in the events lists?
-    addEventListeners(passwordInput, 'change keyup paste cut', checkPasswords);
-    addEventListeners(confirmPassword, 'change keyup paste cut', checkPasswords);
+    addEventListeners(passwordInput, 'input', checkPasswords);
+    addEventListeners(confirmPassword, 'input', checkPasswords);
   };
 });
 


### PR DESCRIPTION
### Scope of changes

This PR amends the event listeners added to the `password` and `confirmation password` input elements.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/29779677?key=421f6a4f14b89374d0db8acfd8a2c076

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


