### PR TITLE
Use htmx trigger to handle success toast when user rejects transaction

### DIFF
--- a/pkg/web/htmx/htmx.go
+++ b/pkg/web/htmx/htmx.go
@@ -52,6 +52,7 @@ func IsHTMXRequest(c *gin.Context) bool {
 	return strings.ToLower(c.GetHeader(HXRequest)) == "true"
 }
 
+// Trigger sets the HX-Trigger response header and returns a 204 no content to allow HTMX to handle the trigger.
 func Trigger(c *gin.Context, event string) {
 	if IsHTMXRequest(c) {
 		c.Header(HXTrigger, event)

--- a/pkg/web/htmx/htmx.go
+++ b/pkg/web/htmx/htmx.go
@@ -51,3 +51,11 @@ func Redirect(c *gin.Context, code int, location string) {
 func IsHTMXRequest(c *gin.Context) bool {
 	return strings.ToLower(c.GetHeader(HXRequest)) == "true"
 }
+
+func Trigger(c *gin.Context, event string) {
+	if IsHTMXRequest(c) {
+		c.Header(HXTrigger, event)
+		c.Status(http.StatusNoContent)
+		return
+	}
+}

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -1,3 +1,5 @@
+import { setSuccessToast } from "./utils.js";
+
 const transactionEl = document.getElementById('transaction-id');
 const transactionID = transactionEl?.value
 
@@ -50,7 +52,10 @@ document.body.addEventListener('htmx:configRequest', (e) => {
 document.body.addEventListener('htmx:afterRequest', (e) => {
   if (e.detail.requestConfig.path === rejectEP && e.detail.requestConfig.verb === 'post' && e.detail.successful) {
     const transactionRejectForm = document.getElementById('transaction-reject-form')
+    const transactionRejectionModal = document.getElementById('transaction_rejection_modal')
+    transactionRejectionModal.close()
     transactionRejectForm.reset()
+    setSuccessToast('Success! The secure envelope has been rejected.')
   }
 });
 

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -1782,6 +1782,10 @@ details.collapse summary::-webkit-details-marker {
           mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' stroke='%23000' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E.spinner_V8m1%7Btransform-origin:center;animation:spinner_zKoa 2s linear infinite%7D.spinner_V8m1 circle%7Bstroke-linecap:round;animation:spinner_YpZS 1.5s ease-out infinite%7D%40keyframes spinner_zKoa%7B100%25%7Btransform:rotate(360deg)%7D%7D%40keyframes spinner_YpZS%7B0%25%7Bstroke-dasharray:0 150;stroke-dashoffset:0%7D47.5%25%7Bstroke-dasharray:42 150;stroke-dashoffset:-16%7D95%25%2C100%25%7Bstroke-dasharray:42 150;stroke-dashoffset:-59%7D%7D%3C%2Fstyle%3E%3Cg class='spinner_V8m1'%3E%3Ccircle cx='12' cy='12' r='9.5' fill='none' stroke-width='3'%3E%3C%2Fcircle%3E%3C%2Fg%3E%3C%2Fsvg%3E");
 }
 
+.loading-md {
+  width: 1.5rem;
+}
+
 .loading-lg {
   width: 2.5rem;
 }
@@ -2834,14 +2838,6 @@ details.collapse summary::-webkit-details-marker {
   height: 1rem;
 }
 
-.h-5 {
-  height: 1.25rem;
-}
-
-.h-48 {
-  height: 12rem;
-}
-
 .max-h-\[450px\] {
   max-height: 450px;
 }
@@ -2874,6 +2870,10 @@ details.collapse summary::-webkit-details-marker {
   width: 11rem;
 }
 
+.w-48 {
+  width: 12rem;
+}
+
 .w-52 {
   width: 13rem;
 }
@@ -2888,14 +2888,6 @@ details.collapse summary::-webkit-details-marker {
 
 .w-full {
   width: 100%;
-}
-
-.w-5 {
-  width: 1.25rem;
-}
-
-.w-48 {
-  width: 12rem;
 }
 
 .min-w-0 {
@@ -2924,18 +2916,6 @@ details.collapse summary::-webkit-details-marker {
 
 .table-fixed {
   table-layout: fixed;
-}
-
-.scale-50 {
-  --tw-scale-x: .5;
-  --tw-scale-y: .5;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.scale-0 {
-  --tw-scale-x: 0;
-  --tw-scale-y: 0;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .transform {
@@ -3667,6 +3647,10 @@ body main {
   background-color: rgb(55 65 81 / 0.8);
 }
 
+.hover\:bg-primary\/80:hover {
+  background-color: var(--fallback-p,oklch(var(--p)/0.8));
+}
+
 .hover\:bg-primary\/90:hover {
   background-color: var(--fallback-p,oklch(var(--p)/0.9));
 }
@@ -3681,10 +3665,6 @@ body main {
 
 .hover\:bg-warning\/80:hover {
   background-color: var(--fallback-wa,oklch(var(--wa)/0.8));
-}
-
-.hover\:bg-primary\/80:hover {
-  background-color: var(--fallback-p,oklch(var(--p)/0.8));
 }
 
 .hover\:text-primary:hover {
@@ -3824,14 +3804,6 @@ body main {
 @media (min-width: 1024px) {
   .lg\:mb-0 {
     margin-bottom: 0px;
-  }
-
-  .lg\:ml-0 {
-    margin-left: 0px;
-  }
-
-  .lg\:ml-4 {
-    margin-left: 1rem;
   }
 
   .lg\:flex {

--- a/pkg/web/templates/components/transaction_rejection.html
+++ b/pkg/web/templates/components/transaction_rejection.html
@@ -8,7 +8,7 @@
       </button>
     </div>
     <div class="my-4">
-      <form id="transaction-reject-form" method="dialog" hx-post="/v1/transactions/{{ .ID }}/reject" hx-ext="json-enc" hx-swap="none">
+      <form id="transaction-reject-form" method="dialog" hx-post="/v1/transactions/{{ .ID }}/reject" hx-ext="json-enc" hx-swap="none" hx-indicator="#spinner">
         <div class="my-4">
           <label for="transaction-rejection" class="label-style">Select a reason for rejecting the transaction:</label>
             <select id="transaction-rejection" name="code"
@@ -50,7 +50,10 @@
         </div>
     </div>
     <div class="flex justify-center">
-      <button class="btn w-44 font-semibold bg-warning text-lg text-white hover:bg-warning/80">Reject</button>
+      <button type="submit" id="reject-btn" class="btn w-44 font-semibold bg-warning text-lg text-white hover:bg-warning/80">
+        <span id="spinner" class="htmx-indicator loading loading-spinner loading-md"></span>      
+        <span id="reject-btn">Reject</span>
+      </button>
     </div>
     </form>
   </div>

--- a/pkg/web/templates/partials/transaction/transaction_info.html
+++ b/pkg/web/templates/partials/transaction/transaction_info.html
@@ -15,7 +15,7 @@
           {{ if $canMngTrans }}
            {{ if and (eq .Source "remote") (ne .Status "completed") }}
             <a href="/transactions/{{ .ID }}/accept" class="p-1 rounded w-32 bg-success font-semibold text-white text-center md:p-2 hover:bg-success/80">Accept</a>
-            <button onclick="transaction_rejection_modal.showModal()" class="p-1 rounded w-32 bg-warning font-semibold text-white md:p-2 hover:bg-warning/80">Reject</button>
+            <a href="/transactions/{{ .ID }}/info" class="p-1 rounded w-32 bg-warning font-semibold text-white text-center md:p-2 hover:bg-warning/80">Reject</a>
             {{ end }}
             {{ if ne .Status "archived" }}
             <button onclick="transaction_modal.close()" class="p-1 rounded w-32 bg-gray-700 font-semibold text-white md:p-2 hover:bg-gray-700/80">Archive</button>
@@ -39,7 +39,7 @@
               <tr>
                 <th scope="row" class="envelope-header">Date Created</th>
                 {{ $created := .Created.Format "2006-01-02T15:04:05-0700" }}
-                <td class="envelope-data text-balance datetime" id="date-created">{{ if .Created }} {{ $created }} {{ else }} N/A {{ end }}</td>
+                <td class="envelope-data text-balance datetime" id="date-created">{{ $created }}</td>
               </tr>
               <tr>
                 <th scope="row" class="envelope-header">Network</th>

--- a/pkg/web/templates/transactions_info.html
+++ b/pkg/web/templates/transactions_info.html
@@ -2,7 +2,7 @@
 {{ define "content" }}
 
 <section class="mx-8 my-14">
-  <section hx-get="/v1/transactions/{{ .ID }}?detail=full" hx-trigger="load">
+  <section hx-get="/v1/transactions/{{ .ID }}?detail=full" hx-trigger="load, transactionRejected from:body">
     <div class="text-center">
       <span class="loading loading-spinner loading-lg"></span>
     </div>
@@ -19,5 +19,5 @@
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1/plugin/relativeTime.js"></script>
 <script>dayjs.extend(window.dayjs_plugin_relativeTime)</script>
 <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"></script>
-<script src="/static/js/transactionInfo.js"></script>
+<script type="module" src="/static/js/transactionInfo.js"></script>
 {{ end }}

--- a/pkg/web/transactions.go
+++ b/pkg/web/transactions.go
@@ -581,7 +581,7 @@ func (s *Server) RejectTransaction(c *gin.Context) {
 	// respond with a 204 no content response and the front-end will handle the
 	// success message in the toast.
 	if c.NegotiateFormat(binding.MIMEJSON, binding.MIMEHTML) == binding.MIMEHTML {
-		c.Status(http.StatusNoContent)
+		htmx.Trigger(c, "transactionRejected")
 		return
 	}
 


### PR DESCRIPTION
### Scope of changes

This PR adds a `htmx-trigger` event to be included as a response header when a user rejects a transaction. Once the event is detected, a success toast will be displayed and the transaction rejection modal will close.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/29930307?key=afdcebc22442a86cf79d29ec4f0ddfce

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


