### PR TITLE
Hotfix Prepare Transaction Panic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envoy",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "main": "",
   "repository": "https://github.com/trisacrypto/envoy.git",
   "author": "TRISA",

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -6,9 +6,9 @@ import "fmt"
 const (
 	VersionMajor         = 0
 	VersionMinor         = 23
-	VersionPatch         = 0
+	VersionPatch         = 1
 	VersionReleaseLevel  = "beta"
-	VersionReleaseNumber = 26
+	VersionReleaseNumber = 27
 )
 
 // Set the GitVersion via -ldflags="-X 'github.com/trisacrypto/envoy/pkg.GitVersion=$(git rev-parse --short HEAD)'"

--- a/pkg/web/api/v1/prepared.go
+++ b/pkg/web/api/v1/prepared.go
@@ -66,11 +66,40 @@ func (p *Prepared) Dump() string {
 	return string(data)
 }
 
-func (p *Prepare) Validate() error {
+func (p *Prepare) Validate() (err error) {
 	if strings.TrimSpace(p.TravelAddress) == "" {
-		return MissingField("travel_address")
+		err = ValidationError(err, MissingField("travel_address"))
 	}
-	return nil
+
+	if p.Originator == nil {
+		err = ValidationError(err, MissingField("originator"))
+	} else {
+		if p.Originator.CryptoAddress == "" {
+			err = ValidationError(err, MissingField("originator.crypto_address"))
+		}
+
+		if p.Originator.Identification == nil {
+			p.Originator.Identification = &Identification{}
+		}
+	}
+
+	if p.Beneficiary == nil {
+		err = ValidationError(err, MissingField("beneficiary"))
+	} else {
+		if p.Beneficiary.CryptoAddress == "" {
+			err = ValidationError(err, MissingField("beneficiary.crypto_address"))
+		}
+
+		if p.Beneficiary.Identification == nil {
+			p.Beneficiary.Identification = &Identification{}
+		}
+	}
+
+	if p.Transfer == nil {
+		err = ValidationError(err, MissingField("transfer"))
+	}
+
+	return err
 }
 
 func (p *Prepared) Validate() error {


### PR DESCRIPTION
### Scope of changes

If the user sends a payload with just a travel address; this endpoint panics. This PR adds better validation to return a 400 error instead of panicking.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This hotfix will be merged without review.