### PR TITLE
Replace hyperscript with setSuccessToast function

### DIFF
--- a/pkg/web/static/js/counterparties.js
+++ b/pkg/web/static/js/counterparties.js
@@ -1,13 +1,17 @@
 import { countriesArray } from './constants.js';
+import { setSuccessToast } from './utils.js';
 
 document.body.addEventListener('htmx:afterRequest', (e) => {
-  const addCpartyForm = 'new-cparty-form';
+  const addCpartyForm = document.getElementById('new-cparty-form');
+  const cpartyModal = document.getElementById('add_cparty_modal');
   // Check if the request to add a new counterparty was successful.
-  if (e.detail.elt.id === addCpartyForm && e.detail.requestConfig.verb === 'post' && e.detail.successful) {
+  if (e.detail.requestConfig.path === '/v1/counterparties' && e.detail.requestConfig.verb === 'post' && e.detail.successful) {
     // Close the add counterparty modal and reset the form.
-    document.getElementById('add_cparty_modal').close();
-    document.getElementById(addCpartyForm).reset();
+    cpartyModal.close();
+    addCpartyForm.reset();
     countrySelect.setSelected({ 'placeholder': true, 'text': 'Select a country', 'value': '' });
+
+    setSuccessToast('Success! A new counterparty VASP has been created.');
   }
 });
 

--- a/pkg/web/static/js/envelope.js
+++ b/pkg/web/static/js/envelope.js
@@ -108,7 +108,7 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
     window.scrollTo(0, 0);
     setSuccessToast('Success! Secure envelope sent.');
   };
-  
+
   disableSubmitButton();
 });
 

--- a/pkg/web/static/js/envelope.js
+++ b/pkg/web/static/js/envelope.js
@@ -1,4 +1,5 @@
 import { IDENTIFIER_TYPE, countriesArray, naturalPersonNtlIdTypeArray } from './constants.js';
+import { setSuccessToast } from './utils.js';
 
 const birthplace = 'birthplace';
 const country = 'country';
@@ -97,5 +98,15 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
       identifierType.textContent = readableIdentifierType || identifierCode;
     });
   }
+
+  if (e.detail.requestConfig.path === '/v1/transactions/send-prepared' && e.detail.requestConfig.verb === 'post' && e.detail.successful) {
+    const previewEnvModal = document.getElementById('preview_envelope');
+    const secureEnvForm = document.getElementById('secure-envelope-form');
+    secureEnvForm.reset();
+    previewEnvModal.close();
+    // Manually reset the screen position to ensure user is at the top of the page.
+    window.scrollTo(0, 0);
+    setSuccessToast('Success! Secure envelope sent.');
+  };
 })
 

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -74,13 +74,5 @@ document.body.addEventListener('htmx:afterRequest', (e) => {
 // Display success toast message if user is redirected to info page after accepting a transaction.
 const transactionSend = Cookies.get('transaction_send_success')
 if (transactionSend === 'true') {
-  const successToast = document.getElementById('success-toast');
-  const successToastMsg = document.getElementById('success-toast-msg');
-  successToast.classList.remove('hidden');
-  successToastMsg.textContent = 'Success! The secure envelope has been accepted.'
-
-  // Remove the toast after 5 seconds.
-  setTimeout(() => {
-    successToast.classList.add('hidden');
-  }, 5000);
+  setSuccessToast('Success! The secure envelope has been accepted.')
 }

--- a/pkg/web/templates/counterparty.html
+++ b/pkg/web/templates/counterparty.html
@@ -25,15 +25,7 @@
       </div>
       <p class="py-4">Add new counterparty VASP details.</p>
       <div>
-        <form 
-        _="on htmx:afterRequest
-          if event.detail.successful
-          remove .hidden from #success-toast
-          put 'Success! A new counterparty VASP has been created.' into #success-toast-msg
-          wait 5s
-          add .hidden to #success-toast
-          end"    
-        id="new-cparty-form" hx-post="/v1/counterparties" hx-ext="json-enc" hx-target="#counterparties" hx-swap-oob="outerHTML:#counterparties" method="post">
+        <form id="new-cparty-form" hx-post="/v1/counterparties" hx-ext="json-enc" hx-target="#counterparties" hx-swap-oob="outerHTML:#counterparties" method="post">
           <div class="mb-4 grid gap-6 md:grid-cols-2">
             <div>
               <label for="name" class="label-style">VASP Name</label>

--- a/pkg/web/templates/partials/transaction/transaction_preview.html
+++ b/pkg/web/templates/partials/transaction/transaction_preview.html
@@ -8,7 +8,7 @@
           Secure Envelope Details: Preview
         </h1>
       </div>
-      <form hx-post="/v1/transactions/send-prepared" hx-swap="none" hx-ext="json-enc" method="post">
+      <form id="preview-form" hx-post="/v1/transactions/send-prepared" hx-swap="none" hx-indicator="#loader" hx-ext="json-enc" method="post">
         <input type="hidden" id="prepared_payload" name="prepared_payload" value="{{ .Dump }}" />
         <div class="flex flex-row gap-x-2 md:gap-4">
           <button id="preview-sbmt-btn" type="submit"

--- a/pkg/web/templates/partials/transaction/transaction_preview.html
+++ b/pkg/web/templates/partials/transaction/transaction_preview.html
@@ -8,17 +8,7 @@
           Secure Envelope Details: Preview
         </h1>
       </div>
-      <form _="on htmx:afterRequest
-              if event.detail.successful
-                remove @open from #preview_envelope
-                then remove .hidden from #success-toast
-                then put 'Success! Secure envelope sent.' into #success-toast-msg
-                then wait 5s
-                then add .hidden to #success-toast
-                then reset() the #secure-envelope-form
-                then reload() the location of the window
-                then go to top of the body" hx-post="/v1/transactions/send-prepared" hx-target="#secure-envelope-form"
-        hx-swap="none" hx-ext="json-enc" method="post">
+      <form hx-post="/v1/transactions/send-prepared" hx-swap="none" hx-ext="json-enc" method="post">
         <input type="hidden" id="prepared_payload" name="prepared_payload" value="{{ .Dump }}" />
         <div class="flex flex-row gap-x-2 md:gap-4">
           <button type="submit"


### PR DESCRIPTION
### Scope of changes

This PR removes `hyperscript` used to display toast message with a JS function.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


