### PR TITLE
Add padding below table and fix overflow

### DIFF
--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2556,18 +2556,6 @@ details.collapse summary::-webkit-details-marker {
   border-bottom-left-radius: 0px;
 }
 
-.table-xs :not(thead):not(tfoot) tr {
-  font-size: 0.75rem;
-  line-height: 1rem;
-}
-
-.table-xs :where(th, td) {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-}
-
 .table-sm :not(thead):not(tfoot) tr {
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -2701,24 +2689,12 @@ details.collapse summary::-webkit-details-marker {
   visibility: collapse;
 }
 
-.absolute {
-  position: absolute;
-}
-
 .relative {
   position: relative;
 }
 
 .z-\[1\] {
   z-index: 1;
-}
-
-.z-10 {
-  z-index: 10;
-}
-
-.z-50 {
-  z-index: 50;
 }
 
 .m-auto {
@@ -2862,22 +2838,6 @@ details.collapse summary::-webkit-details-marker {
   height: 1rem;
 }
 
-.h-full {
-  height: 100%;
-}
-
-.h-screen {
-  height: 100vh;
-}
-
-.h-\[1080px\] {
-  height: 1080px;
-}
-
-.h-\[5000px\] {
-  height: 5000px;
-}
-
 .max-h-\[450px\] {
   max-height: 450px;
 }
@@ -2888,15 +2848,6 @@ details.collapse summary::-webkit-details-marker {
 
 .max-h-screen {
   max-height: 100vh;
-}
-
-.max-h-fit {
-  max-height: -moz-fit-content;
-  max-height: fit-content;
-}
-
-.min-h-full {
-  min-height: 100%;
 }
 
 .w-1\/2 {
@@ -2959,13 +2910,13 @@ details.collapse summary::-webkit-details-marker {
   max-width: 80rem;
 }
 
-.max-w-sm {
-  max-width: 24rem;
-}
-
 .max-w-fit {
   max-width: -moz-fit-content;
   max-width: fit-content;
+}
+
+.max-w-sm {
+  max-width: 24rem;
 }
 
 .table-fixed {
@@ -3043,24 +2994,8 @@ details.collapse summary::-webkit-details-marker {
        column-gap: 1.5rem;
 }
 
-.gap-y-2 {
-  row-gap: 0.5rem;
-}
-
-.gap-y-4 {
-  row-gap: 1rem;
-}
-
-.gap-y-24 {
-  row-gap: 6rem;
-}
-
 .gap-y-3 {
   row-gap: 0.75rem;
-}
-
-.overflow-auto {
-  overflow: auto;
 }
 
 .overflow-x-auto {
@@ -3073,18 +3008,6 @@ details.collapse summary::-webkit-details-marker {
 
 .overflow-y-hidden {
   overflow-y: hidden;
-}
-
-.overflow-y-visible {
-  overflow-y: visible;
-}
-
-.overflow-x-scroll {
-  overflow-x: scroll;
-}
-
-.whitespace-nowrap {
-  white-space: nowrap;
 }
 
 .text-balance {
@@ -3341,6 +3264,10 @@ details.collapse summary::-webkit-details-marker {
   padding-bottom: 0.75rem;
 }
 
+.pb-36 {
+  padding-bottom: 9rem;
+}
+
 .pt-16 {
   padding-top: 4rem;
 }
@@ -3351,22 +3278,6 @@ details.collapse summary::-webkit-details-marker {
 
 .pt-4 {
   padding-top: 1rem;
-}
-
-.pb-4 {
-  padding-bottom: 1rem;
-}
-
-.pb-20 {
-  padding-bottom: 5rem;
-}
-
-.pb-60 {
-  padding-bottom: 15rem;
-}
-
-.pb-36 {
-  padding-bottom: 9rem;
 }
 
 .text-left {
@@ -3838,10 +3749,6 @@ body main {
 }
 
 @media (min-width: 640px) {
-  .sm\:flex {
-    display: flex;
-  }
-
   .sm\:flex-row {
     flex-direction: row;
   }
@@ -3988,15 +3895,5 @@ body main {
 @media (min-width: 1280px) {
   .xl\:w-1\/4 {
     width: 25%;
-  }
-
-  .xl\:pb-4 {
-    padding-bottom: 1rem;
-  }
-}
-
-@media (min-width: 1536px) {
-  .\32xl\:pb-4 {
-    padding-bottom: 1rem;
   }
 }

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2556,6 +2556,18 @@ details.collapse summary::-webkit-details-marker {
   border-bottom-left-radius: 0px;
 }
 
+.table-xs :not(thead):not(tfoot) tr {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.table-xs :where(th, td) {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
 .table-sm :not(thead):not(tfoot) tr {
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -2689,12 +2701,24 @@ details.collapse summary::-webkit-details-marker {
   visibility: collapse;
 }
 
+.absolute {
+  position: absolute;
+}
+
 .relative {
   position: relative;
 }
 
 .z-\[1\] {
   z-index: 1;
+}
+
+.z-10 {
+  z-index: 10;
+}
+
+.z-50 {
+  z-index: 50;
 }
 
 .m-auto {
@@ -2838,6 +2862,22 @@ details.collapse summary::-webkit-details-marker {
   height: 1rem;
 }
 
+.h-full {
+  height: 100%;
+}
+
+.h-screen {
+  height: 100vh;
+}
+
+.h-\[1080px\] {
+  height: 1080px;
+}
+
+.h-\[5000px\] {
+  height: 5000px;
+}
+
 .max-h-\[450px\] {
   max-height: 450px;
 }
@@ -2848,6 +2888,15 @@ details.collapse summary::-webkit-details-marker {
 
 .max-h-screen {
   max-height: 100vh;
+}
+
+.max-h-fit {
+  max-height: -moz-fit-content;
+  max-height: fit-content;
+}
+
+.min-h-full {
+  min-height: 100%;
 }
 
 .w-1\/2 {
@@ -2912,6 +2961,11 @@ details.collapse summary::-webkit-details-marker {
 
 .max-w-sm {
   max-width: 24rem;
+}
+
+.max-w-fit {
+  max-width: -moz-fit-content;
+  max-width: fit-content;
 }
 
 .table-fixed {
@@ -2989,12 +3043,48 @@ details.collapse summary::-webkit-details-marker {
        column-gap: 1.5rem;
 }
 
+.gap-y-2 {
+  row-gap: 0.5rem;
+}
+
+.gap-y-4 {
+  row-gap: 1rem;
+}
+
+.gap-y-24 {
+  row-gap: 6rem;
+}
+
+.gap-y-3 {
+  row-gap: 0.75rem;
+}
+
+.overflow-auto {
+  overflow: auto;
+}
+
 .overflow-x-auto {
   overflow-x: auto;
 }
 
 .overflow-y-auto {
   overflow-y: auto;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+
+.overflow-y-visible {
+  overflow-y: visible;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
 }
 
 .text-balance {
@@ -3261,6 +3351,22 @@ details.collapse summary::-webkit-details-marker {
 
 .pt-4 {
   padding-top: 1rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
+.pb-20 {
+  padding-bottom: 5rem;
+}
+
+.pb-60 {
+  padding-bottom: 15rem;
+}
+
+.pb-36 {
+  padding-bottom: 9rem;
 }
 
 .text-left {
@@ -3731,6 +3837,28 @@ body main {
   --tw-ring-color: rgb(229 231 235 / var(--tw-ring-opacity));
 }
 
+@media (min-width: 640px) {
+  .sm\:flex {
+    display: flex;
+  }
+
+  .sm\:flex-row {
+    flex-direction: row;
+  }
+
+  .sm\:items-center {
+    align-items: center;
+  }
+
+  .sm\:justify-between {
+    justify-content: space-between;
+  }
+
+  .sm\:gap-y-0 {
+    row-gap: 0px;
+  }
+}
+
 @media (min-width: 768px) {
   .md\:m-8 {
     margin: 2rem;
@@ -3860,5 +3988,15 @@ body main {
 @media (min-width: 1280px) {
   .xl\:w-1\/4 {
     width: 25%;
+  }
+
+  .xl\:pb-4 {
+    padding-bottom: 1rem;
+  }
+}
+
+@media (min-width: 1536px) {
+  .\32xl\:pb-4 {
+    padding-bottom: 1rem;
   }
 }

--- a/pkg/web/templates/counterparty.html
+++ b/pkg/web/templates/counterparty.html
@@ -1,10 +1,10 @@
 {{ template "base" . }}
 {{ define "content" }}
   <section class="mx-8 py-14">
-    <section class="flex gap-x-6 mb-12">
+    <section class="md:flex md:items-center md:gap-x-6 mb-12">
       <h1 class="font-bold text-2xl">Counterparty VASPs</h1>
       {{ if not .IsViewOnly }}
-      <button onclick="add_cparty_modal.showModal()" class="btn btn-sm bg-primary text-white hover:bg-primary/90">Add New VASP</button>
+      <button onclick="add_cparty_modal.showModal()" class="mt-3 md:mt-0 btn btn-sm bg-primary text-white hover:bg-primary/90">Add New VASP</button>
       {{ end }}
     </section>
     <section id="counterparties" hx-get="/v1/counterparties" hx-trigger="load">

--- a/pkg/web/templates/partials/account/account_list.html
+++ b/pkg/web/templates/partials/account/account_list.html
@@ -1,6 +1,6 @@
 {{ $canEditAccounts := not .IsViewOnly }}
 {{- with .AccountsList -}}
-<div class="table-container">
+<div class="table-container pb-36 overflow-x-auto overflow-y-hidden">
   <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr>

--- a/pkg/web/templates/partials/counterparty/counterparty_list.html
+++ b/pkg/web/templates/partials/counterparty/counterparty_list.html
@@ -1,6 +1,6 @@
 {{- $canEditAccounts := not .IsViewOnly -}}
 {{- with .CounterpartyList -}}
-<div class="table-container">
+<div class="table-container pb-36 overflow-x-auto overflow-y-hidden">
   <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr>

--- a/pkg/web/templates/partials/transaction/transaction_list.html
+++ b/pkg/web/templates/partials/transaction/transaction_list.html
@@ -1,6 +1,6 @@
 {{ $canMngTrans := not .IsViewOnly }}
 {{- with .TransactionsList -}}
-<div class="table-container">
+<div class="table-container pb-36 overflow-x-auto overflow-y-hidden">
   <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr class="text-center text-balance">

--- a/pkg/web/templates/partials/user/user_list.html
+++ b/pkg/web/templates/partials/user/user_list.html
@@ -1,6 +1,6 @@
 {{- $isAdmin := .IsAdmin -}}
 {{- with .UserList -}}
-<div class="table-container">
+<div class="table-container pb-36 overflow-x-auto overflow-y-hidden">
   <table class="table table-sm">
     <thead class="font-bold text-base text-black">
       <tr>

--- a/pkg/web/templates/transactions.html
+++ b/pkg/web/templates/transactions.html
@@ -22,7 +22,7 @@
   <section class="mb-12">
     <h1 class="font-bold text-2xl">Transaction Inbox</h1>
     {{ if or (.HasRole "Admin") (.HasRole "Compliance") }}
-    <div class="mt-6 flex justify-between items-center">
+    <div class="mt-6 flex flex-col sm:flex-row gap-y-3 sm:gap-y-0 sm:justify-between sm:items-center">
       <div class="flex items-center gap-x-1">
         <a href="/send-envelope" class="btn btn-sm bg-primary text-white hover:bg-primary/90">Send New Secure Envelope</a>
         <div class="tooltip tooltip-top md:tooltip-right" data-tip="Messages are sent as Secure Envelopes. Secure Envelopes are encrypted messages designed to securely exchange compliance data. Secure Envelopes ensure privacy, non-repudiation, and long-term storage.">
@@ -31,7 +31,7 @@
           </button> 
         </div>
       </div>
-      <a href="/v1/transactions/export" download class="btn btn-sm bg-black text-white hover:bg-black/80">Export Transactions</a>
+      <a href="/v1/transactions/export" download class="max-w-fit btn btn-sm bg-black text-white hover:bg-black/80">Export Transactions</a>
     </div>
     {{ end }}  
   </section>


### PR DESCRIPTION
### Scope of changes

This PR sets the `overflow-x` value to auto for tables and adds padding below each table to ensure the scrollbars will not prevent users from being able to view the action menu components.

It also includes some minor CSS fixes to improve the appearance for small screens.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/30206344?key=3ecd4ccc0d583e604c06eaa7b1339717

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


