### PR TITLE
Replace hyperscript in accounts template w/ JS function

### DIFF
--- a/pkg/web/static/js/customerAccounts.js
+++ b/pkg/web/static/js/customerAccounts.js
@@ -1,4 +1,6 @@
 import { networksArray } from "./constants.js";
+import { networkSelect } from "./networkSelect.js";
+import { setSuccessToast } from "./utils.js";
 
 const addWalletBttn = document.getElementById('add-wallet-bttn')
 const extractWalletRE = /(crypto_address|network)_(\d+)/g;
@@ -95,6 +97,7 @@ document.body.addEventListener('htmx:afterRequest', (e) => {
     newAcctModal?.close()
     document.getElementById(newAcctForm).reset()
     networkSelect.setSelected({ 'placeholder': true, 'text': 'Select a country', 'value': '' })
+    setSuccessToast('Success! A new customer account has been created.');
 
     // If user added more than 1 wallet, remove the additional wallets.
     while (walletDiv?.children.length > 1) {

--- a/pkg/web/static/js/networkSelect.js
+++ b/pkg/web/static/js/networkSelect.js
@@ -2,7 +2,7 @@ import { networksArray } from "./constants.js";
 
 const networkContentDiv = document.getElementById('network-content')
 // Display a searchable dropdown for networks.
-const networkSelect = new SlimSelect({
+export const networkSelect = new SlimSelect({
   select: '#networks',
   settings: {
     contentLocation: networkContentDiv,

--- a/pkg/web/templates/accounts.html
+++ b/pkg/web/templates/accounts.html
@@ -26,13 +26,6 @@
       <p class="py-4">Add new customer account details.</p>
       <div>
         <form
-          _="on htmx:afterRequest
-          if event.detail.successful
-            remove .hidden from #success-toast
-            put 'Success! A new customer account has been created.' into #success-toast-msg
-            wait 5s
-            add .hidden to #success-toast
-          end" 
           id="new-acct-form"
           hx-post="/v1/accounts" 
           hx-ext="json-enc" 


### PR DESCRIPTION
### Scope of changes

This PR replaces the hyperscript to display a success toast notification in the `accounts.html` partial with the `setSuccessToast` JS function. It also resolves an error that prevented the `network` value from resetting in the add account modal.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


