### PR TITLE
Add conditionals to fix rendering bug when values not provided

### DIFF
--- a/pkg/web/templates/partials/transaction/transaction_accept.html
+++ b/pkg/web/templates/partials/transaction/transaction_accept.html
@@ -51,7 +51,7 @@
       <h2 class="my-4 font-bold">2. ORIGINATOR DETAILS</h2>
       {{ $originatorPersons := .Identity.Originator.OriginatorPersons }}
       {{ if gt (len $originatorPersons) 0 }}
-        {{ $originator := (index .Identity.Originator.OriginatorPersons 0).Person.NaturalPerson }}
+        {{ $originator := (index $originatorPersons 0).Person.NaturalPerson }}
         {{ $originatorName := $originator.Name.NameIdentifiers }}
         {{ $originatorAddress := $originator.GeographicAddresses }}
       <div class="my-5">

--- a/pkg/web/templates/partials/transaction/transaction_accept.html
+++ b/pkg/web/templates/partials/transaction/transaction_accept.html
@@ -49,10 +49,11 @@
     </section>
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">2. ORIGINATOR DETAILS</h2>
-      {{ $originator := (index .Identity.Originator.OriginatorPersons 0).Person.NaturalPerson }}
-      {{ $originatorName := $originator.Name.NameIdentifiers }}
-      {{ $originatorAddress := $originator.GeographicAddresses }}
-
+      {{ $originatorPersons := .Identity.Originator.OriginatorPersons }}
+      {{ if gt (len $originatorPersons) 0 }}
+        {{ $originator := (index .Identity.Originator.OriginatorPersons 0).Person.NaturalPerson }}
+        {{ $originatorName := $originator.Name.NameIdentifiers }}
+        {{ $originatorAddress := $originator.GeographicAddresses }}
       <div class="my-5">
         {{ range $originatorName }}
         <div class="grid gap-6 my-4 md:grid-cols-2">
@@ -102,9 +103,7 @@
         </div>
         {{ end }}
 
-
         {{ range $originatorAddress }}
-        
         <div class="grid gap-6 my-4 md:grid-cols-2">
           {{ range $index, $origAddrLine := .AddressLine }}
           <div>
@@ -161,7 +160,6 @@
             <input type="hidden" class="originator_id_national_identifier_type" value="{{ $originatorNationalIdentification.NationalIdentifierType }}" data-id="natural-person-ntl-id-type" />
           </div>
         </div>
-       
 
         <div class="my-4">
           <label for="originator_id_country_of_issue" class="label-style">Country of Issue</label>
@@ -180,7 +178,6 @@
             <input type="hidden" class="originator_id_national_identifier_type" value="" data-id="natural-person-ntl-id-type" />
           </div>
         </div>
-       
 
         <div class="my-4">
           <label for="originator_id_country_of_issue" class="label-style">Country of Issue</label>
@@ -196,12 +193,105 @@
         </div>
         {{ end }}
       </div>
+      {{ else }}
+      <div class="my-5">
+        <div class="grid gap-6 my-4 md:grid-cols-2">
+          <div>
+            <label for="orig_primary_identifier" class="label-style">Primary Identifier</label>
+            <input type="text" id="orig_primary_identifier" name="id_og_primary_identifier" value="" class="input-style" />
+          </div>
+          <div>
+            <label for="orig_secondary_identifier" class="label-style">Secondary Identifier</label>
+            <input type="text" id="orig_secondary_identifier" name="id_og_secondary_identifier" value="" class="input-style" />
+          </div>
+        </div>
+        <div>
+          <label for="orig_name_identifier_type" class="label-style">Name Identifier Type</label>
+          <select id="orig_name_identifier_type" name="id_og_name_identifier_type" class="identifier-types"></select>
+          <input type="hidden" class="orig_name_identifier_type" value="" data-id="natural-person-name-type" />
+        </div>
+      
+        <div class="grid gap-6 my-4 md:grid-cols-2">
+          <div>
+            <label for="originator_birth_date_of_birth" class="label-style">Date of Birth</label>
+            <input type="date" id="originator_birth_date_of_birth" name="originator_birth_date_of_birth" value="" class="input-style" />
+          </div>
+          <div>
+            <label for="originator_birth_place_of_birth" class="label-style">Place of Birth</label>
+            <select id="originator_birth_place_of_birth" name="originator_birth_place_of_birth" class="countries"></select>
+            <input type="hidden" class="originator_birth_place_of_birth" value="" />
+          </div>
+        </div>
+        
+        <div class="grid gap-6 my-4 md:grid-cols-2">
+          <div>
+            <label for="orig_street_name" class="label-style">Address Line</label>
+            <input type="text" id="orig_street_name" name="address_og_0" value="" class="input-style" />
+          </div>
+          <div>
+            <label for="orig_street_name" class="label-style">Address Line</label>
+            <input type="text" id="orig_street_name" name="address_og_1" value="" class="input-style" />
+          </div>
+          <div>
+            <label for="orig_street_name" class="label-style">Address Line</label>
+            <input type="text" id="orig_street_name" name="address_og_2" value="" class="input-style" />
+          </div>
+          <div>
+            <label for="orig_country" class="label-style">Country</label>
+            <select id="orig_country" name="addr_og_country" class="countries"></select>
+            <input type="hidden" class="orig_country" value="" />
+          </div>
+        </div>
+        <div>
+          <label for="orig_address_type" class="label-style">Address Type</label>
+          <select id="orig_address_type" name="addr_og_address_type" class="identifier-types"></select>
+          <input type="hidden" class="orig_address_type" value="" data-id="address-identifier-type" />
+        </div>
+      
+        <div class="grid gap-6 my-4 md:grid-cols-2">
+          <div>
+            <label for="orig_country_of_residence" class="label-style">Country of Residence</label>
+            <select id="orig_country_of_residence" name="np_og_country_of_residence" class="countries"></select>
+            <input type="hidden" class="orig_country_of_residence" value="" />
+          </div>
+          <div>
+            <label for="orig_customer_identification" class="label-style">Customer Identification</label>
+            <input type="text" id="orig_customer_identification" name="np_og_customer_identification" value="" class="input-style" />
+          </div>
+        </div>
+      
+        <div class="grid gap-6 my-4 md:grid-cols-2">
+          <div>
+            <label for="originator_id_national_identifier" class="label-style">National Identifier Number</label>
+            <input type="text" id="originator_id_national_identifier" name="originator_id_national_identifier" value="" class="input-style" />
+          </div>
+          <div>
+            <label for="originator_id_national_identifier_type" class="label-style">National Identifier Type</label>
+            <select id="originator_id_national_identifier_type" name="originator_id_national_identifier_type" class="identifier-types"></select>
+            <input type="hidden" class="originator_id_national_identifier_type" value="" data-id="natural-person-ntl-id-type" />
+          </div>
+        </div>
+       
+        <div class="my-4">
+          <label for="originator_id_country_of_issue" class="label-style">Country of Issue</label>
+          <select id="originator_id_country_of_issue" name="originator_id_country_of_issue" class="countries"></select>
+          <input type="hidden" class="originator_id_country_of_issue" value="" />
+        </div>
+      
+        <div>
+          <label for="orig_account_numbers" class="label-style">Account Number</label>
+          <input type="text" id="orig_account_numbers" name="acct_og_account_numbers" value="" class="input-style" />
+        </div>
+      </div>
+      {{ end }}
     </section>
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">3. BENEFICIARY DETAILS </h2>
-      {{ $beneficiary := (index .Identity.Beneficiary.BeneficiaryPersons 0).Person.NaturalPerson }}
-      {{ $beneficiaryName := $beneficiary.Name.NameIdentifiers }}
-      {{ $beneficiaryAddress := $beneficiary.GeographicAddresses }}
+      {{ $beneficiaryPersons := .Identity.Beneficiary.BeneficiaryPersons }}
+      {{ if gt (len $beneficiaryPersons) 0 }}
+        {{ $beneficiary := (index $beneficiaryPersons 0).Person.NaturalPerson }}
+        {{ $beneficiaryName := $beneficiary.Name.NameIdentifiers }}
+        {{ $beneficiaryAddress := $beneficiary.GeographicAddresses }}
       <div class="my-5">
         {{ range $beneficiaryName }}
         <div class="grid gap-6 my-4 md:grid-cols-2">
@@ -340,13 +430,108 @@
           <input type="text" id="benf_account_numbers" name="acct_bf_account_numbers" value="{{ . }}" class="input-style" />
         </div>
         {{ end }}
+
+        {{ else }}
+        <div class="my-5">
+          <div class="grid gap-6 my-4 md:grid-cols-2">
+            <div>
+              <label for="benf_primary_identifier" class="label-style">Primary Identifier</label>
+              <input type="text" id="benf_primary_identifier" name="id_bf_primary_identifier" value="" class="input-style" />
+            </div>
+            <div>
+              <label for="benf_secondary_identifier" class="label-style">Secondary Identifier</label>
+              <input type="text" id="benf_secondary_identifier" name="id_bf_secondary_identifier" value="" class="input-style" />
+            </div>
+          </div>
+          <div>
+            <label for="benf_name_identifier_type" class="label-style">Name Identifier Type</label>
+            <select id="benf_name_identifier_type" name="id_bf_name_identifier_type" class="identifier-types"></select>
+            <input type="hidden" class="benf_name_identifier_type" value="" data-id="natural-person-name-type" />
+          </div>
+        
+          <div class="grid gap-6 my-4 md:grid-cols-2">
+            <div>
+              <label for="beneficiary_birth_date_of_birth" class="label-style">Date of Birth</label>
+              <input type="date" id="beneficiary_birth_date_of_birth" name="beneficiary_birth_date_of_birth" value="" class="input-style" />
+            </div>
+            <div>
+              <label for="beneficiary_birth_place_of_birth" class="label-style">Place of Birth</label>
+              <select id="beneficiary_birth_place_of_birth" name="beneficiary_birth_place_of_birth" class="countries"></select>
+              <input type="hidden" class="beneficiary_birth_place_of_birth" value="" />
+            </div>
+          </div>
+        
+          <div class="grid gap-6 my-4 md:grid-cols-2">
+            <div>
+              <label for="benf_street_name" class="label-style">Address Line</label>
+              <input type="text" id="benf_street_name" name="address_bf_street_name_0" value="" class="input-style" />
+            </div>
+            <div>
+              <label for="benf_street_name" class="label-style">Address Line</label>
+              <input type="text" id="benf_street_name" name="address_bf_street_name_1" value="" class="input-style" />
+            </div>
+            <div>
+              <label for="benf_street_name" class="label-style">Address Line</label>
+              <input type="text" id="benf_street_name" name="address_bf_street_name_2" value="" class="input-style" />
+            </div>
+        
+            <div>
+              <label for="benf_country" class="label-style">Country</label>
+              <select id="benf_country" id="benf_country" name="addr_bf_country" class="countries"></select>
+              <input type="hidden" class="benf_country" value="" />
+            </div>
+          </div>
+        
+          <div>
+            <label for="benf_address_type" class="label-style">Address Type</label>
+            <select id="benf_address_type" name="addr_bf_address_type" class="identifier-types"></select>
+            <input type="hidden" class="benf_address_type" value="" data-id="address-identifier-type" />
+          </div>
+        
+          <div class="grid gap-6 my-4 md:grid-cols-2">
+            <div>
+              <label for="benf_country_of_residence" class="label-style">Country of Residence</label>
+              <select id="benf_country_of_residence" name="np_bf_country_of_residence" class="countries"></select>
+              <input type="hidden" class="benf_country_of_residence" value="" />
+            </div>
+            <div>
+              <label for="benf_customer_identification" class="label-style">Customer Identification</label>
+              <input type="text" id="benf_customer_identification" name="np_bf_customer_identification" value="" class="input-style" />
+            </div>
+          </div>
+        
+          <div class="grid gap-6 my-4 md:grid-cols-2">
+            <div>
+              <label for="beneficiary_id_national_identifier" class="label-style">National Identifier Number</label>
+              <input type="text" id="beneficiary_id_national_identifier" name="beneficiary_id_national_identifier" value="" class="input-style" />
+            </div>
+            <div>
+              <label for="beneficiary_id_national_identifier_type" class="label-style">National Identifier Type</label>
+              <select id="beneficiary_id_national_identifier_type" name="beneficiary_id_national_identifier_type" class="identifier-types"></select>
+              <input type="hidden" class="beneficiary_id_national_identifier_type" value="" data-id="natural-person-ntl-id-type" />
+            </div>
+          </div>
+        
+          <div class="my-4">
+            <label for="beneficiary_id_country_of_issue" class="label-style">Country of Issue</label>
+            <select id="beneficiary_id_country_of_issue" name="beneficiary_id_country_of_issue" class="countries"></select>
+            <input type="hidden" class="beneficiary_id_country_of_issue" value="" />
+          </div>
+        
+          <div>
+            <label for="benf_account_numbers" class="label-style">Account Number</label>
+            <input type="text" id="benf_account_numbers" name="acct_bf_account_numbers" value="" class="input-style" />
+          </div>
+        </div>
+        {{ end }}
       </div>
     </section>
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">4. ORIGINATING VASP DETAILS </h2>
       <div class="my-5">
-        {{ $originatingVasp := .Identity.OriginatingVasp.OriginatingVasp.Person.LegalPerson }}
-        {{ $originatingLegalPerson := $originatingVasp.Name }}
+        {{ if .Identity.OriginatingVasp }}
+          {{ $originatingVasp := .Identity.OriginatingVasp.OriginatingVasp.Person.LegalPerson }}
+          {{ $originatingLegalPerson := $originatingVasp.Name }}
 
         {{ range $originatingLegalPerson.NameIdentifiers }}
         <div class="grid gap-6 my-4 md:grid-cols-2">
@@ -435,11 +620,81 @@
           </div>
         </div>
       </div>
+      {{ else }}
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="orig_vasp_legal_person_name" class="label-style">Legal Person Name</label>
+          <input type="text" id="orig_vasp_legal_person_name" name="id_orig_legal_person_name" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier Type</label>
+          <select id="orig_vasp_legal_person_name_identifier_type" name="id_orig_legal_person_name_identifier_type"class="identifier-types"></select>
+          <input type="hidden" class="orig_vasp_legal_person_name_identifier_type" value="" data-id="legal-person-name-type" />
+        </div>
+      </div>
+      
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="orig_vasp_street_name" class="label-style">Address Line</label>
+          <input type="text" id="orig_vasp_street_name" name="address_orig_0" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_street_name" class="label-style">Address Line</label>
+          <input type="text" id="orig_vasp_street_name" name="address_orig_1" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_street_name" class="label-style">Address Line</label>
+          <input type="text" id="orig_vasp_street_name" name="address_orig_2" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_country" class="label-style">Country</label>
+          <select id="orig_vasp_country" name="addr_orig_country" class="countries"></select>
+          <input type="hidden" class="orig_vasp_country" value="" />
+        </div>
+      </div>
+      <div>
+        <label for="orig_vasp_address_type" class="label-style">Address Type</label>
+        <select id="orig_vasp_address_type" name="addr_orig_address_type" class="identifier-types"></select>
+        <input type="hidden" class="orig_vasp_address_type" value="" data-id="address-identifier-type" />
+      </div>
+      
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="orig_vasp_national_identifier" class="label-style">National Identifier</label>
+          <input type="text" id="orig_vasp_national_identifier" name="nat_orig_national_identifier" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_national_identifier_type" class="label-style">National Identifier Type</label>
+          <select id="orig_vasp_national_identifier_type" name="nat_orig_national_identifier_type" class="identifier-types"></select>
+          <input type="hidden" class="orig_vasp_national_identifier_type" value="" data-id="national-identifier-type" />
+        </div>
+      </div>
+      
+      <div>
+        <label for="orig_vasp_country_of_issue" class="label-style">Country of Issue</label>
+        <select id="orig_vasp_country_of_issue" name="nat_orig_country_of_issue" class="countries"></select>
+        <input type="hidden" class="orig_vasp_country_of_issue" value="" />
+      </div>
+      
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="orig_vasp_registration_authority" class="label-style">Registration Authority</label>
+          <input type="text" id="orig_vasp_registration_authority" name="nat_orig_registration_authority" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="orig_vasp_country_of_registration" class="label-style">Country of Registration</label>
+          <select id="orig_vasp_country_of_registration" name="ctry_orig_country_of_registration"
+            class="countries"></select>
+          <input type="hidden" class="orig_vasp_country_of_registration" value="" />
+        </div>
+      </div>
+      {{ end }}
     </section>
     <section class="py-2 border-t border-t-black">
       <h2 class="my-4 font-bold">5. BENEFICIARY VASP DETAILS </h2>
       <div class="my-5">
-        {{ $beneficiaryVasp := .Identity.BeneficiaryVasp.BeneficiaryVasp.Person.LegalPerson }}
+        {{ if .Identity.BeneficiaryVasp }}
+          {{ $beneficiaryVasp := .Identity.BeneficiaryVasp.BeneficiaryVasp.Person.LegalPerson }}
 
         {{ range $beneficiaryVasp.Name.NameIdentifiers }}
         <div class="grid gap-6 my-4 md:grid-cols-2">
@@ -528,6 +783,72 @@
           </div>
         </div>
       </div>
+      {{ else }}
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="benf_vasp_legal_person_name" class="label-style">Name Identifier</label>
+          <input type="text" id="benf_vasp_legal_person_name" name="id_benf_legal_person_name" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier Type</label>
+          <select id="benf_vasp_legal_person_name_identifier_type" name="id_benf_legal_person_name_identifier_type" class="identifier-types"></select>
+          <input type="hidden" class="benf_vasp_legal_person_name_identifier_type" value="" data-id="legal-person-name-type" />
+        </div>
+      </div>
+    
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="benf_vasp_street_name" class="label-style">Address Line</label>
+          <input type="text" id="benf_vasp_street_name" name="address_benf_address_line_0" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_street_name" class="label-style">Address Line</label>
+          <input type="text" id="benf_vasp_street_name" name="address_benf_address_line_1" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_street_name" class="label-style">Address Line</label>
+          <input type="text" id="benf_vasp_street_name" name="address_benf_address_line_2" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_country" class="label-style">Country</label>
+          <select id="benf_vasp_country" name="addr_benf_country" class="countries"></select>
+          <input type="hidden" class="benf_vasp_country" value="" />
+        </div>
+      </div>
+      <div>
+        <label for="benf_vasp_address_type" class="label-style">Address Type</label>
+        <select id="benf_vasp_address_type" name="addr_benf_address_type" class="identifier-types"></select>
+        <input type="hidden" class="benf_vasp_address_type" value="" data-id="address-identifier-type" />
+      </div>
+    
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="benf_vasp_national_identifier" class="label-style">National Identifier</label>
+          <input type="text" id="benf_vasp_national_identifier" name="nat_benf_national_identifier" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_national_identifier_type" class="label-style">National Identifier Type</label>
+          <select id="benf_vasp_national_identifier_type" name="nat_benf_national_identifier_type" class="identifier-types"></select>
+          <input type="hidden" class="benf_vasp_national_identifier_type" value="" data-id="national-identifier-type" />
+        </div>
+      </div>
+      <div>
+        <label for="benf_vasp_country_of_issue" class="label-style">Country of Issue</label>
+        <select id="benf_vasp_country_of_issue" name="nat_benf_country_of_issue" class="countries"></select>
+        <input type="hidden" class="benf_vasp_country_of_issue" value="" />
+      </div>
+      <div class="grid gap-6 my-4 md:grid-cols-2">
+        <div>
+          <label for="benf_vasp_registration_authority" class="label-style">Registration Authority</label>
+          <input type="text" id="benf_vasp_registration_authority" name="nat_benf_registration_authority" value="" class="input-style" />
+        </div>
+        <div>
+          <label for="benf_vasp_country_of_registration" class="label-style">Country of Registration</label>
+          <select id="benf_vasp_country_of_registration" name="ctry_benf_country_of_registration" class="countries"></select>
+          <input type="hidden" class="benf_vasp_country_of_registration" value="" />
+        </div>
+      </div>
+      {{ end }}
     </section>
     <div class="py-4 flex justify-center items-center gap-x-2">
       <button id="accept-sbmt-btn" type="submit" class="btn p-1 w-36 bg-success font-semibold text-lg text-white md:p-2 hover:bg-success/80">


### PR DESCRIPTION
### Scope of changes

This PR fixes a bug that prevented the transaction accept form from fully rendering if an envelope request was sent with only a travel address and wallet addresses.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Test locally by sending an envelope with only the travel address and wallet addresses for the originator and beneficiary and then by sending one with more details.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


