### PR TITLE
Add API key table and delete confirmation modal

### DIFF
--- a/pkg/web/api/v1/apikey.go
+++ b/pkg/web/api/v1/apikey.go
@@ -46,9 +46,7 @@ func NewAPIKey(model *models.APIKey) (out *APIKey, err error) {
 
 func NewAPIKeyList(page *models.APIKeyPage) (out *APIKeyList, err error) {
 	out = &APIKeyList{
-		Page: &PageQuery{
-			PageSize: int(page.Page.PageSize),
-		},
+		Page:    &PageQuery{},
 		APIKeys: make([]*APIKey, 0, len(page.APIKeys)),
 	}
 

--- a/pkg/web/apikeys.go
+++ b/pkg/web/apikeys.go
@@ -53,6 +53,7 @@ func (s *Server) ListAPIKeys(c *gin.Context) {
 		Offered:  []string{binding.MIMEJSON, binding.MIMEHTML},
 		Data:     out,
 		HTMLName: "apikey_list.html",
+		HTMLData: scene.New(c).WithAPIData(out),
 	})
 }
 

--- a/pkg/web/apikeys.go
+++ b/pkg/web/apikeys.go
@@ -53,7 +53,6 @@ func (s *Server) ListAPIKeys(c *gin.Context) {
 		Offered:  []string{binding.MIMEJSON, binding.MIMEHTML},
 		Data:     out,
 		HTMLName: "apikey_list.html",
-		HTMLData: scene.New(c).WithAPIData(out),
 	})
 }
 

--- a/pkg/web/static/styles/output.css
+++ b/pkg/web/static/styles/output.css
@@ -2920,6 +2920,14 @@ details.collapse summary::-webkit-details-marker {
   max-height: 100vh;
 }
 
+.max-h-16 {
+  max-height: 4rem;
+}
+
+.max-h-64 {
+  max-height: 16rem;
+}
+
 .w-1\/2 {
   width: 50%;
 }
@@ -3080,6 +3088,10 @@ details.collapse summary::-webkit-details-marker {
 
 .overflow-y-hidden {
   overflow-y: hidden;
+}
+
+.overflow-y-scroll {
+  overflow-y: scroll;
 }
 
 .text-balance {

--- a/pkg/web/templates/apikeys.html
+++ b/pkg/web/templates/apikeys.html
@@ -8,11 +8,11 @@
     <button onclick="add_apikey_modal.showModal()" class="mt-3 md:mt-0 btn btn-sm bg-primary text-white hover:bg-primary/90">Add API Key</button>
     {{ end }}
   </section>
-  <!-- <section id="transactions" hx-get="/v1/apikeys" hx-ext="json-enc" hx-trigger="load">
+  <section id="apikeys" hx-get="/v1/apikeys" hx-ext="json-enc" hx-trigger="load">
     <div class="text-center">
       <span class="loading loading-spinner loading-lg"></span>
     </div>
-  </section> -->
+  </section>
 
   <!-- Add API Key Modal -->
   {{ template "add_apikey.html" . }}

--- a/pkg/web/templates/components/add_apikey.html
+++ b/pkg/web/templates/components/add_apikey.html
@@ -33,13 +33,8 @@
             </div>
           </div>
         </section>
-        <section class="p-2 my-4 border border-gray-300 rounded">
-          <div class="flex justify-between">
-            <label for="custom_access" class="font-bold">Custom Access</label>
-            <div class="pt-1">
-              <input type="checkbox" id="custom_access" class="checkbox-style" />
-            </div>
-          </div>
+        <section class="max-h-64 overflow-y-scroll p-2 my-4 border border-gray-300 rounded">
+          <h3 class="font-bold">Custom Access</h3>
           <div class="my-2 grid grid-cols-2 items-center">
             <label for="accounts_manage">accounts:manage</label>
             <input type="checkbox" id="accounts_manage" name="permissions[]" value="accounts:manage" class="checkbox-style" />

--- a/pkg/web/templates/partials/apikey/apikey_delete.html
+++ b/pkg/web/templates/partials/apikey/apikey_delete.html
@@ -6,11 +6,9 @@
       <span class="sr-only">Close modal</span>
     </button>
   </div>
-  <!-- TODO: Add the API key name in the confirmation message. -->
   <p class="my-4">
     Are you sure you want to delete the API key? This action cannot be undone.
   </p>
-  <!-- TODO: Does the hx-ext attribute need to be added to the button? -->
    <div class="my-4 flex justify-center">
     <button
     id="del-key-btn"

--- a/pkg/web/templates/partials/apikey/apikey_delete.html
+++ b/pkg/web/templates/partials/apikey/apikey_delete.html
@@ -1,13 +1,13 @@
 <div class="modal-box">
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-xl">Delete API Key</h1>
+    <h1 class="font-bold text-xl">Revoke API Key</h1>
     <button onclick="apikey_modal.close()" class="btn btn-sm btn-circle btn-ghost">
       <i class="fa-solid fa-x"></i>
       <span class="sr-only">Close modal</span>
     </button>
   </div>
   <p class="my-4">
-    Are you sure you want to delete the API key? This action cannot be undone.
+    Are you sure you want to revoke the API key? This action cannot be undone.
   </p>
    <div class="my-4 flex justify-center">
     <button

--- a/pkg/web/templates/partials/apikey/apikey_delete.html
+++ b/pkg/web/templates/partials/apikey/apikey_delete.html
@@ -1,1 +1,22 @@
-<div></div>
+<div class="modal-box">
+  <h1 class="font-bold text-xl">Delete API Key</h1>
+  <!-- TODO: Add the API key name in the confirmation message. -->
+  <p class="my-4">
+    Are you sure you want to delete the API key? This action cannot be undone.
+  </p>
+  <!-- TODO: Does the hx-ext attribute need to be added to the button? -->
+   <div class="my-4 flex justify-center">
+    <button
+    id="del-key-btn"
+    class="submit-btn w-44 btn bg-primary font-semibold text-lg text-white hover:bg-primary/90"
+    type="button"
+    hx-delete="/v1/apikeys/{{ .ID }}"
+    hx-target="#apikeys"
+    hx-swap="innerHTML"
+    hx-indicator="#loader"
+  >
+    <span class="submit-btn-text">Delete</span>
+    <span id="loader" class="htmx-indicator loading loading-spinner loading-md"></span>
+  </button>
+   </div>
+</div>

--- a/pkg/web/templates/partials/apikey/apikey_delete.html
+++ b/pkg/web/templates/partials/apikey/apikey_delete.html
@@ -1,5 +1,11 @@
 <div class="modal-box">
-  <h1 class="font-bold text-xl">Delete API Key</h1>
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-xl">Delete API Key</h1>
+    <button onclick="apikey_modal.close()" class="btn btn-sm btn-circle btn-ghost">
+      <i class="fa-solid fa-x"></i>
+      <span class="sr-only">Close modal</span>
+    </button>
+  </div>
   <!-- TODO: Add the API key name in the confirmation message. -->
   <p class="my-4">
     Are you sure you want to delete the API key? This action cannot be undone.

--- a/pkg/web/templates/partials/apikey/apikey_list.html
+++ b/pkg/web/templates/partials/apikey/apikey_list.html
@@ -1,1 +1,30 @@
-<div></div>
+<div class="table-container pb-36 overflow-x-auto overflow-y-hidden">
+  <table class="table table-sm">
+    <thead class="font-bold text-base text-black">
+      <tr>
+        <th>Description</th>
+        <th>Permissions</th>
+        <th>Date Created</th>
+        <th>Last Used</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ if .APIKeys }}
+      {{ range .APIKeys }}
+        <tr>
+          <td>{{ .Description }}</td>
+          <td>{{ .Permissions }}</td>
+          {{ $created := .Created.Format "2006-01-02T15:04:05-0700" }}
+          <td class="datetime">{{ $created }}</td>
+          {{ $lastUsed := .LastSeen.Format "2006-01-02T15:04:05-0700" }}
+          <td class="datetime">{{ $lastUsed }}</td>
+        </tr>
+      {{ end }}
+      {{ else }}
+        <tr class="text-center">
+          <td colspan="4" class="py-5 text-base">No API keys have been created.</td>
+        </tr>
+      {{ end }}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
### Scope of changes

This PR adds views for the api key table and delete api key confirmation modal. The add api key modal has also been updated so that the custom access permissions section has a scroll bar.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Note: The `Delete API Key` button displayed in the video appears only to show the modal. It's not included in the changes.
https://www.awesomescreenshot.com/video/30504975?key=aa0481d058c5c25007661d9bcc2a0fe1

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


