### PR TITLE
Make Pool Optional for mTLS Configuration

### DIFF
--- a/pkg/config/certs.go
+++ b/pkg/config/certs.go
@@ -1,10 +1,92 @@
 package config
 
-import "github.com/trisacrypto/trisa/pkg/trust"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/trisacrypto/trisa/pkg/trust"
+)
 
 type CertsCacheLoader interface {
 	Validate() error
 	LoadCerts() (*trust.Provider, error)
 	LoadPool() (trust.ProviderPool, error)
 	Reset()
+}
+
+var (
+	ErrMTLSPoolNotConfigured  = errors.New("invalid configuration: no certificate pool found")
+	ErrMTLSCertsNotConfigured = errors.New("invalid configuration: no certificates found")
+)
+
+type MTLSConfig struct {
+	Pool  string `required:"false" desc:"path to the x509 cert pool to use for mTLS connection authentication (optional)"`
+	Certs string `required:"false" desc:"path to the x509 certificate and private key for mTLS authentication, with or without the certificate chain"`
+	certs *trust.Provider
+	pool  trust.ProviderPool
+}
+
+// LoadCerts returns the mtls trust provider for setting up an mTLS 1.3 config.
+// NOTE: this method is not thread-safe, ensure it is not used from multiple go-routines
+func (c *MTLSConfig) LoadCerts() (_ *trust.Provider, err error) {
+	// Attempt to load the certificates from disk and cache them.
+	if c.certs == nil {
+		if err = c.load(); err != nil {
+			return nil, err
+		}
+	}
+
+	// If no certificates are available, return a configuration error
+	if c.certs == nil {
+		return nil, ErrMTLSCertsNotConfigured
+	}
+	return c.certs, nil
+}
+
+// LoadPool returns the mtls TRISA trust provider pool for creating an x509.Pool.
+// NOTE: this method is not thread-safe, ensure it is not used from multiple go-routines
+func (c *MTLSConfig) LoadPool() (_ trust.ProviderPool, err error) {
+	if len(c.pool) == 0 && c.certs == nil {
+		if err = c.load(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Load either the configured certificate pool or use the certs chain specified.
+	switch {
+	case c.pool != nil:
+		return c.pool, nil
+	case c.certs != nil:
+		return trust.NewPool(c.certs), nil
+	default:
+		return nil, ErrMTLSPoolNotConfigured
+	}
+}
+
+// Load and cache the certificates and provider pool from disk.
+func (c *MTLSConfig) load() (err error) {
+	var sz *trust.Serializer
+	if sz, err = trust.NewSerializer(false); err != nil {
+		return err
+	}
+
+	if c.Certs != "" {
+		if c.certs, err = sz.ReadFile(c.Certs); err != nil {
+			return fmt.Errorf("could not parse certs: %w", err)
+		}
+	}
+
+	if c.Pool != "" {
+		if c.pool, err = sz.ReadPoolFile(c.Pool); err != nil {
+			return fmt.Errorf("could not parse cert pool: %w", err)
+		}
+	}
+	return nil
+}
+
+// Reset the certs cache to force load the pool and certs again
+// NOTE: this method is not thread-safe, ensure it is not used from multiple go-routines
+func (c *MTLSConfig) Reset() {
+	c.pool = nil
+	c.certs = nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -213,9 +213,9 @@ func TestTRISAConfig(t *testing.T) {
 	}
 
 	// A valid TRISA config requires paths to certs and a pool
-	require.EqualError(t, conf.Validate(), "invalid configuration: specify pool and cert paths")
+	require.EqualError(t, conf.Validate(), "invalid configuration: specify certificates path")
 	conf.Pool = "testdata/trisa.example.dev.pem"
-	require.EqualError(t, conf.Validate(), "invalid configuration: specify pool and cert paths")
+	require.EqualError(t, conf.Validate(), "invalid configuration: specify certificates path")
 	conf.Certs = conf.Pool
 	require.NoError(t, conf.Validate(), "expected configuration was valid")
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -279,7 +279,7 @@ func TestCertsConfigCache(t *testing.T) {
 	}
 
 	t.Run("TRISAConfig", createTest(&conf))
-	t.Run("TRPConfig", createTest(&config.TRPConfig{Certs: path, Pool: path}))
+	t.Run("TRPConfig", createTest(&config.TRPConfig{MTLSConfig: config.MTLSConfig{Certs: path, Pool: path}}))
 
 	t.Run("ByReference", func(t *testing.T) {
 		var (

--- a/pkg/directory/sync_test.go
+++ b/pkg/directory/sync_test.go
@@ -24,8 +24,10 @@ func TestStartStop(t *testing.T) {
 
 	conf := config.Config{
 		Node: config.TRISAConfig{
-			Pool:                "testdata/trisatest.dev.pem",
-			Certs:               "testdata/client.trisatest.dev.pem",
+			MTLSConfig: config.MTLSConfig{
+				Pool:  "testdata/trisatest.dev.pem",
+				Certs: "testdata/client.trisatest.dev.pem",
+			},
 			KeyExchangeCacheTTL: 24 * time.Hour,
 			Directory: config.DirectoryConfig{
 				Insecure:        true,
@@ -85,8 +87,10 @@ func TestSync(t *testing.T) {
 
 	conf := config.Config{
 		Node: config.TRISAConfig{
-			Pool:                "testdata/trisatest.dev.pem",
-			Certs:               "testdata/client.trisatest.dev.pem",
+			MTLSConfig: config.MTLSConfig{
+				Pool:  "testdata/trisatest.dev.pem",
+				Certs: "testdata/client.trisatest.dev.pem",
+			},
 			KeyExchangeCacheTTL: 24 * time.Hour,
 			Directory: config.DirectoryConfig{
 				Insecure:        true,

--- a/pkg/trisa/interceptors/maintenance_test.go
+++ b/pkg/trisa/interceptors/maintenance_test.go
@@ -20,8 +20,10 @@ func TestMaintenanceInterceptor(t *testing.T) {
 	// Create a mock maintenance mode TRISA server
 	conf := config.TRISAConfig{
 		Maintenance: true,
-		Certs:       "testdata/certs/alice.vaspbot.net.pem",
-		Pool:        "testdata/certs/trisatest.dev.pem",
+		MTLSConfig: config.MTLSConfig{
+			Certs: "testdata/certs/alice.vaspbot.net.pem",
+			Pool:  "testdata/certs/trisatest.dev.pem",
+		},
 	}
 
 	opts := []grpc.ServerOption{

--- a/pkg/trisa/network/dialer_test.go
+++ b/pkg/trisa/network/dialer_test.go
@@ -12,8 +12,10 @@ import (
 
 func TestDialers(t *testing.T) {
 	conf := config.TRISAConfig{
-		Certs: "testdata/notreal.pem",
-		Pool:  "testdata/notreal.pem",
+		MTLSConfig: config.MTLSConfig{
+			Certs: "testdata/notreal.pem",
+			Pool:  "testdata/notreal.pem",
+		},
 	}
 
 	_, err := network.TRISADialer(conf)

--- a/pkg/trisa/network/mock.go
+++ b/pkg/trisa/network/mock.go
@@ -24,8 +24,10 @@ import (
 func NewMocked(conf *config.TRISAConfig) (_ Network, err error) {
 	if conf == nil {
 		conf = &config.TRISAConfig{
-			Pool:                "testdata/pool.pem",
-			Certs:               "testdata/alice.pem",
+			MTLSConfig: config.MTLSConfig{
+				Pool:  "testdata/pool.pem",
+				Certs: "testdata/alice.pem",
+			},
 			KeyExchangeCacheTTL: 1 * time.Second,
 			Directory: config.DirectoryConfig{
 				Insecure:        true,

--- a/pkg/trisa/network/network_test.go
+++ b/pkg/trisa/network/network_test.go
@@ -61,7 +61,7 @@ func TestFromContext(t *testing.T) {
 	require.Len(t, opts, 1, "dial options contains unexpected number of things")
 
 	// Create an mTLS RemotePeer gRPC server for testing
-	conf := config.TRISAConfig{Certs: "testdata/alice.pem", Pool: "testdata/pool.pem"}
+	conf := config.TRISAConfig{MTLSConfig: config.MTLSConfig{Certs: "testdata/alice.pem", Pool: "testdata/pool.pem"}}
 	bufnet := bufconn.New()
 	remote, err := pmock.NewAuth(bufnet, conf)
 	require.NoError(t, err, "could not create authenticated remote peer mock")

--- a/pkg/trisa/trisa_test.go
+++ b/pkg/trisa/trisa_test.go
@@ -49,11 +49,13 @@ func (s *trisaTestSuite) SetupSuite() {
 	s.conn = bufconn.New()
 	s.echan = make(chan error, 1)
 	s.conf = config.TRISAConfig{
-		Maintenance:         false,
-		Enabled:             true,
-		BindAddr:            "bufnet",
-		Certs:               "testdata/certs/alice.vaspbot.net.pem",
-		Pool:                "testdata/certs/trisatest.dev.pem",
+		Maintenance: false,
+		Enabled:     true,
+		BindAddr:    "bufnet",
+		MTLSConfig: config.MTLSConfig{
+			Certs: "testdata/certs/alice.vaspbot.net.pem",
+			Pool:  "testdata/certs/trisatest.dev.pem",
+		},
 		KeyExchangeCacheTTL: 60 * time.Second,
 		Directory: config.DirectoryConfig{
 			Insecure:        true,


### PR DESCRIPTION
### Scope of changes

This PR decouples the mTLS configuration from the TRISA and TRP nodes and unifies handling. It also makes the Pool configuration optional, loading the pool from the certs if they are not specified. Because of the use of embedding, some of the tests had to be changed to create Config objects from scratch.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Does this adequately fix the bug, e.g. does it correctly ensure pool is optional? Does the Envoy node still work and is still able to send and receive TRISA messages without the POOL configuration? 

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.
- [ ] Envoy can still send and receive TRISA messages without a POOL configuration