### PR TITLE
Ensure toast msg disappears and update conditional for displaying buttons on info page

### DIFF
--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -75,4 +75,5 @@ document.body.addEventListener('htmx:afterRequest', (e) => {
 const transactionSend = Cookies.get('transaction_send_success')
 if (transactionSend === 'true') {
   setSuccessToast('Success! The secure envelope has been accepted.')
+  Cookies.remove('transaction_send_success')
 }

--- a/pkg/web/static/js/transactionInfo.js
+++ b/pkg/web/static/js/transactionInfo.js
@@ -75,5 +75,4 @@ document.body.addEventListener('htmx:afterRequest', (e) => {
 const transactionSend = Cookies.get('transaction_send_success')
 if (transactionSend === 'true') {
   setSuccessToast('Success! The secure envelope has been accepted.')
-  Cookies.remove('transaction_send_success')
 }

--- a/pkg/web/static/js/utils.js
+++ b/pkg/web/static/js/utils.js
@@ -4,7 +4,7 @@ export function setSuccessToast(msg) {
   successToast.classList.remove('hidden');
   successToastMsg.textContent = msg;
 
-  // Remove the toast after 5 seconds.
+  // Remove the toast after 2.5 seconds.
   setTimeout(() => {
     successToast.classList.add('hidden');
   }, 2250);

--- a/pkg/web/templates/partials/transaction/transaction_detail.html
+++ b/pkg/web/templates/partials/transaction/transaction_detail.html
@@ -10,7 +10,7 @@
     </div>
     <div class="flex gap-x-4">
       {{ if $canMngTrans }}
-      {{ if and (eq .Source "remote") (and (ne .Status "completed") (ne .Status "accepted") (ne .Status "rejected")) }}
+      {{ if and (eq .Source "remote") (and (eq .Status "review")) }}
       <a href="/transactions/{{ .ID }}/accept"
         class="p-1 rounded w-32 bg-success font-semibold text-white text-center md:p-2 hover:bg-success/80">Accept</a>
       <button onclick="transaction_rejection_modal.showModal()"

--- a/pkg/web/transactions.go
+++ b/pkg/web/transactions.go
@@ -1138,5 +1138,5 @@ func CheckUUIDMatch(id, target uuid.UUID) error {
 
 func setToastCookie(c *gin.Context, name, value, path, domain string) {
 	secure := !auth.IsLocalhost(domain)
-	c.SetCookie(name, value, -1, path, domain, secure, false)
+	c.SetCookie(name, value, 1, path, domain, secure, false)
 }

--- a/pkg/web/transactions.go
+++ b/pkg/web/transactions.go
@@ -1138,5 +1138,5 @@ func CheckUUIDMatch(id, target uuid.UUID) error {
 
 func setToastCookie(c *gin.Context, name, value, path, domain string) {
 	secure := !auth.IsLocalhost(domain)
-	c.SetCookie(name, value, 60, path, domain, secure, false)
+	c.SetCookie(name, value, -1, path, domain, secure, false)
 }


### PR DESCRIPTION
### Scope of changes

This PR fixes an issue where a toast notification appeared in the UI multiple times if a user navigated away from the `/info` page and then back to it after completing the repair or success workflow.

A change has also been made to display the `Accept` and `Reject` buttons only when a transaction's state is `Review`.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


