### PR TITLE
API Changes and Fixes

### DIFF
--- a/pkg/web/api/v1/transaction.go
+++ b/pkg/web/api/v1/transaction.go
@@ -54,7 +54,7 @@ type SecureEnvelope struct {
 	EnvelopeID          uuid.UUID    `json:"envelope_id"`
 	Direction           string       `json:"direction"`
 	Remote              string       `json:"remote,omitempty"`
-	ReplyTo             ulid.ULID    `json:"reply_to,omitempty"`
+	ReplyTo             *ulid.ULID   `json:"reply_to"`
 	Payload             []byte       `json:"payload,omitempty"`
 	EncryptionKey       []byte       `json:"encryption_key,omitempty"`
 	EncryptionAlgorithm string       `json:"encryption_algorithm,omitempty"`
@@ -76,7 +76,7 @@ type Envelope struct {
 	EnvelopeID         string                   `json:"envelope_id,omitempty"`
 	Direction          string                   `json:"direction"`
 	Remote             string                   `json:"remote,omitempty"`
-	ReplyTo            ulid.ULID                `json:"reply_to,omitempty"`
+	ReplyTo            *ulid.ULID               `json:"reply_to"`
 	IsError            bool                     `json:"is_error"`
 	Error              *trisa.Error             `json:"error,omitempty"`
 	Identity           *ivms101.IdentityPayload `json:"identity,omitempty"`
@@ -84,10 +84,10 @@ type Envelope struct {
 	Pending            *generic.Pending         `json:"pending,omitempty"`
 	SentAt             *time.Time               `json:"sent_at"`
 	ReceivedAt         *time.Time               `json:"received_at,omitempty"`
-	Timestamp          time.Time                `json:"timestamp"`
+	Timestamp          time.Time                `json:"timestamp,omitempty"`
 	PublicKeySignature string                   `json:"public_key_signature,omitempty"`
 	TransferState      string                   `json:"transfer_state,omitempty"`
-	Original           []byte                   `json:"original,omitempty"`
+	SecureEnvelope     *SecureEnvelope          `json:"secure_envelope,omitempty"`
 }
 
 type Rejection struct {
@@ -309,7 +309,6 @@ func NewSecureEnvelope(model *models.SecureEnvelope) (out *SecureEnvelope, err e
 		EnvelopeID:          model.EnvelopeID,
 		Direction:           model.Direction,
 		Remote:              model.Remote.String,
-		ReplyTo:             model.ReplyTo.ULID,
 		Payload:             model.Envelope.Payload,
 		EncryptionKey:       model.EncryptionKey,
 		EncryptionAlgorithm: model.Envelope.EncryptionAlgorithm,
@@ -323,6 +322,10 @@ func NewSecureEnvelope(model *models.SecureEnvelope) (out *SecureEnvelope, err e
 		Sealed:              model.Envelope.Sealed,
 		PublicKeySignature:  model.PublicKey.String,
 		TransferState:       model.Envelope.TransferState.String(),
+	}
+
+	if model.ReplyTo.Valid {
+		out.ReplyTo = &model.ReplyTo.ULID
 	}
 
 	if out.Original, err = proto.Marshal(model.Envelope); err != nil {
@@ -358,13 +361,17 @@ func NewEnvelope(model *models.SecureEnvelope, env *envelope.Envelope) (out *Env
 		EnvelopeID:         model.EnvelopeID.String(),
 		Direction:          model.Direction,
 		Remote:             model.Remote.String,
-		ReplyTo:            model.ReplyTo.ULID,
 		Timestamp:          model.Timestamp,
 		PublicKeySignature: model.PublicKey.String,
 		TransferState:      env.TransferState().String(),
 	}
 
-	if out.Original, err = proto.Marshal(model.Envelope); err != nil {
+	if model.ReplyTo.Valid {
+		out.ReplyTo = &model.ReplyTo.ULID
+	}
+
+	// Add the secure envelope to the envelope detail to include metadata
+	if out.SecureEnvelope, err = NewSecureEnvelope(model); err != nil {
 		return nil, err
 	}
 

--- a/pkg/web/api/v1/transaction.go
+++ b/pkg/web/api/v1/transaction.go
@@ -345,6 +345,15 @@ func NewSecureEnvelopeList(page *models.SecureEnvelopePage) (out *EnvelopesList,
 		if env, err = NewSecureEnvelope(model); err != nil {
 			return nil, err
 		}
+
+		// Reduce the amount of information being sent in a list request
+		// These fields can be obtained using a detail request
+		env.Payload = nil
+		env.EncryptionKey = nil
+		env.HMACSecret = nil
+		env.HMAC = nil
+		env.Original = nil
+
 		out.SecureEnvelopes = append(out.SecureEnvelopes, env)
 	}
 
@@ -443,6 +452,14 @@ func NewEnvelopeList(page *models.SecureEnvelopePage, envelopes []*envelope.Enve
 		if env, err = NewEnvelope(model, envelopes[i]); err != nil {
 			return nil, err
 		}
+
+		// Reduce the amount of information being sent in a list request
+		// These fields can be obtained using a detail request
+		env.Identity = nil
+		env.Transaction = nil
+		env.Pending = nil
+		env.SecureEnvelope = nil
+
 		out.DecryptedEnvelopes = append(out.DecryptedEnvelopes, env)
 	}
 

--- a/pkg/web/templates/openapi/openapi.json
+++ b/pkg/web/templates/openapi/openapi.json
@@ -26,7 +26,7 @@
   "tags": [
     {
       "name": "authentication",
-      "description": "Allow for authentication against Envoy node."
+      "description": "Authenticate with client ID and secret to receive a JWT Bearer token."
     },
     {
       "name": "account",
@@ -34,15 +34,15 @@
     },
     {
       "name": "crypto_address",
-      "description": "Associate crypto addresses with user accounts."
-    },
-    {
-      "name": "transaction",
-      "description": "Travel Rule information exchanges for specific crypto asset transactions."
+      "description": "Associate crypto addresses with customer accounts."
     },
     {
       "name": "counterparty",
       "description": "Counterparties to exchange travel rule information with using TRISA or TRP protocols."
+    },
+    {
+      "name": "transaction",
+      "description": "Travel Rule information exchanges for specific crypto asset transactions."
     },
     {
       "name": "secure_envelope",
@@ -50,11 +50,15 @@
     },
     {
       "name": "user",
-      "description": "User management."
+      "description": "Envoy user access management."
+    },
+    {
+      "name": "apikey",
+      "description": "Envoy api key credentials and access management."
     },
     {
       "name": "utility",
-      "description": "Other useful methods."
+      "description": "Other useful methods and helpers."
     }
   ],
   "paths": {
@@ -465,48 +469,6 @@
         }
       }
     },
-    "/v1/transactions/{transactionID}/preview": {
-      "get": {
-        "tags": [
-          "transaction"
-        ],
-        "summary": "Preview transaction envelope",
-        "description": "Preview the transaction envelope for a specific transaction",
-        "operationId": "previewTransaction",
-        "security": [
-          {
-            "bearer-auth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "transactionID",
-            "in": "path",
-            "description": "ID of transaction to preview",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "UUID"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Transaction not found"
-          }
-        }
-      }
-    },
     "/v1/transactions/{transactionID}/send": {
       "post": {
         "tags": [
@@ -561,6 +523,46 @@
       }
     },
     "/v1/transactions/{transactionID}/accept": {
+      "get": {
+        "tags": [
+          "transaction"
+        ],
+        "summary": "Preview envelope to accept a transaction",
+        "description": "Preview envelope that can be sent to accept a travel rule exchange",
+        "operationId": "previewAccept",
+        "security": [
+          {
+            "bearer-auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "transactionID",
+            "in": "path",
+            "description": "ID of transaction to preview",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Transaction not found"
+          }
+        }
+      },
       "post": {
         "tags": [
           "transaction"
@@ -598,9 +600,6 @@
           },
           "404": {
             "description": "Transaction not found"
-          },
-          "501": {
-            "description": "Not implemented"
           }
         }
       }
@@ -641,6 +640,88 @@
           },
           "required": true
         },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Transaction not found"
+          }
+        }
+      }
+    },
+    "/v1/transactions/{transactionID}/repair": {
+      "get": {
+        "tags": [
+          "transaction"
+        ],
+        "summary": "Preview envelope to repair a transaction",
+        "description": "Preview envelope that can be sent to repair a travel rule exchange after rejection.",
+        "operationId": "previewRepair",
+        "security": [
+          {
+            "bearer-auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "transactionID",
+            "in": "path",
+            "description": "ID of transaction to preview",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Transaction not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "transaction"
+        ],
+        "summary": "Send repair transaction envelope",
+        "description": "Repair the incoming transaction envelope for a specific transaction",
+        "operationId": "repairTransaction",
+        "security": [
+          {
+            "bearer-auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "transactionID",
+            "in": "path",
+            "description": "ID of transaction to repair",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "UUID"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful operation",
@@ -1902,6 +1983,223 @@
         }
       }
     },
+    "/v1/apikeys": {
+      "get": {
+        "tags": [
+          "apikey"
+        ],
+        "summary": "List API Keys",
+        "description": "Returns a paginated list of all api keys that have been issued",
+        "operationId": "listAPIKeys",
+        "security": [
+          {
+            "bearer-auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "next_page_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "prev_page_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyList"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "apikey"
+        ],
+        "summary": "Create a new API Key",
+        "description": "Request a new api key be generated with the specified description and permissions",
+        "operationId": "createAPIKey",
+        "security": [
+          {
+            "bearer-auth": []
+          }
+        ],
+        "requestBody": {
+          "description": "Only description and permissions are allowed to be posted",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIKey"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "API Key created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "422": {
+            "description": "Validation error or missing fields"
+          }
+        }
+      }
+    },
+    "/v1/apikeys/{keyID}": {
+      "get": {
+        "tags": [
+          "apikey"
+        ],
+        "summary": "Request API Key detail",
+        "description": "Returns detailed response about an API Key",
+        "operationId": "apikeyDetail",
+        "security": {
+          "bearer-auth": []
+        },
+        "parameters": [
+          {
+            "name": "keyID",
+            "in": "path",
+            "description": "id or client id of api key to return",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKey"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "apikey"
+        ],
+        "summary": "Update an api key record",
+        "description": "Update an api key description (note this is the only field that can be updated)",
+        "operationId": "updateAPIKey",
+        "security": [
+          {
+            "bearer-auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "keyID",
+            "in": "path",
+            "description": "id or client id of api key to return",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "update API Key data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIKey"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation exception or missing fields"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "apikey"
+        ],
+        "summary": "Revoke an api key",
+        "description": "Revoke an api key",
+        "operationId": "revokeAPIKey",
+        "security": [
+          {
+            "bearer-auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "keyID",
+            "in": "path",
+            "description": "id or client id of api key to return",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "404": {
+            "description": "API Key not found"
+          }
+        }
+      }
+    },
     "/v1/utilities/travel-address/encode": {
       "post": {
         "tags": [
@@ -2908,6 +3206,65 @@
           "decoded": {
             "type": "string",
             "description": "The decoded travel address."
+          }
+        }
+      },
+      "APIKey": {
+        "type": "object",
+        "description": "An complete APIKey representation",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "ULID",
+            "description": "The unique identifier of the API key"
+          },
+          "description": {
+            "type": "string",
+            "description": "A textual description to help users identity the API key"
+          },
+          "client_id": {
+            "type": "string",
+            "description": "The client id of the API key used for authentication"
+          },
+          "secret": {
+            "type": "string",
+            "description": "The client secret of the API key used for authentication; only shown on create."
+          },
+          "last_seen": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The last timestamp that the API key was used for authentication"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date and time when the API key was created."
+          },
+          "modified": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date and time when the API key was last modified."
+          }
+        }
+      },
+      "APIKeyList": {
+        "type": "object",
+        "description": "A list of API key summaries",
+        "properties": {
+          "page": {
+            "$ref": "#/components/schemas/PageQuery"
+          },
+          "api_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/APIKey"
+            }
           }
         }
       }

--- a/pkg/web/templates/openapi/openapi.yaml
+++ b/pkg/web/templates/openapi/openapi.yaml
@@ -23,21 +23,23 @@ servers:
     description: "{{ .Description }}"
 tags:
   - name: authentication
-    description: Allow for authentication against Envoy node.
+    description: Authenticate with client ID and secret to receive a JWT Bearer token.
   - name: account
     description: Stored information about your user/customer accounts.
   - name: crypto_address
-    description: Associate crypto addresses with user accounts.
-  - name: transaction
-    description: Travel Rule information exchanges for specific crypto asset transactions.
+    description: Associate crypto addresses with customer accounts.
   - name: counterparty
     description: Counterparties to exchange travel rule information with using TRISA or TRP protocols.
+  - name: transaction
+    description: Travel Rule information exchanges for specific crypto asset transactions.
   - name: secure_envelope
     description: Secure Envelopes provide an audit record of travel rule exchanges with a counterparty.
   - name: user
-    description: User management.
+    description: Envoy user access management.
+  - name: apikey
+    description: Envoy api key credentials and access management.
   - name: utility
-    description: Other useful methods.
+    description: Other useful methods and helpers.
 paths:
   /v1/status:
     get:
@@ -289,32 +291,6 @@ paths:
           description: Invalid input
         '422':
           description: Validation exception or missing field
-  /v1/transactions/{transactionID}/preview:
-    get:
-      tags:
-        - transaction
-      summary: Preview transaction envelope
-      description: Preview the transaction envelope for a specific transaction
-      operationId: previewTransaction
-      security:
-        - bearer-auth: [ ]
-      parameters:
-        - name: transactionID
-          in: path
-          description: ID of transaction to preview
-          required: true
-          schema:
-            type: string
-            format: UUID
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Envelope'
-        '404':
-          description: Transaction not found
   /v1/transactions/{transactionID}/send:
     post:
       tags:
@@ -349,6 +325,31 @@ paths:
         '404':
           description: Transaction not found
   /v1/transactions/{transactionID}/accept:
+    get:
+      tags:
+        - transaction
+      summary: Preview envelope to accept a transaction
+      description: Preview envelope that can be sent to accept a travel rule exchange
+      operationId: previewAccept
+      security:
+        - bearer-auth: [ ]
+      parameters:
+        - name: transactionID
+          in: path
+          description: ID of transaction to preview
+          required: true
+          schema:
+            type: string
+            format: UUID
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Envelope'
+        '404':
+          description: Transaction not found
     post:
       tags:
         - transaction
@@ -374,8 +375,6 @@ paths:
                 $ref: '#/components/schemas/Envelope'
         '404':
           description: Transaction not found
-        '501':
-          description: Not implemented
   /v1/transactions/{transactionID}/reject:
     post:
       tags:
@@ -400,6 +399,57 @@ paths:
             schema:
               $ref: '#/components/schemas/Rejection'
         required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Envelope'
+        '404':
+          description: Transaction not found
+  /v1/transactions/{transactionID}/repair:
+    get:
+      tags:
+        - transaction
+      summary: Preview envelope to repair a transaction
+      description: Preview envelope that can be sent to repair a travel rule exchange after rejection.
+      operationId: previewRepair
+      security:
+        - bearer-auth: [ ]
+      parameters:
+        - name: transactionID
+          in: path
+          description: ID of transaction to preview
+          required: true
+          schema:
+            type: string
+            format: UUID
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Envelope'
+        '404':
+          description: Transaction not found
+    post:
+      tags:
+        - transaction
+      summary: Send repair transaction envelope
+      description: Repair the incoming transaction envelope for a specific transaction
+      operationId: repairTransaction
+      security:
+        - bearer-auth: [ ]
+      parameters:
+        - name: transactionID
+          in: path
+          description: ID of transaction to repair
+          required: true
+          schema:
+            type: string
+            format: UUID
       responses:
         '200':
           description: Successful operation
@@ -1183,6 +1233,139 @@ paths:
           description: Invalid input
         '404':
           description: User not found
+  /v1/apikeys:
+    get:
+      tags:
+        - apikey
+      summary: List API Keys
+      description: Returns a paginated list of all api keys that have been issued
+      operationId: listAPIKeys
+      security:
+        - bearer-auth: [ ]
+      parameters:
+        - name: page_size
+          in: query
+          schema:
+            type: integer
+        - name: next_page_token
+          in: query
+          schema:
+            type: string
+        - name: prev_page_token
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKeyList'
+    post:
+      tags:
+        - apikey
+      summary: Create a new API Key
+      description: Request a new api key be generated with the specified description and permissions 
+      operationId: createAPIKey
+      security:
+        - bearer-auth: [ ]
+      requestBody:
+        description: Only description and permissions are allowed to be posted
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/APIKey'
+      responses:
+        '200':
+          description: API Key created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKey'
+        '400':
+          description: Invalid input
+        '422':
+          description: Validation error or missing fields
+  /v1/apikeys/{keyID}:
+    get:
+      tags:
+        - apikey
+      summary: Request API Key detail 
+      description: Returns detailed response about an API Key
+      operationId: apikeyDetail
+      security:
+        bearer-auth: [ ]
+      parameters:
+        - name: keyID
+          in: path
+          description: id or client id of api key to return
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKey'
+        '404':
+          description: Not Found
+    put:
+      tags:
+        - apikey
+      summary: Update an api key record
+      description: Update an api key description (note this is the only field that can be updated)
+      operationId: updateAPIKey
+      security:
+        - bearer-auth: [ ]
+      parameters:
+        - name: keyID
+          in: path
+          description: id or client id of api key to return
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: update API Key data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/APIKey'
+      responses:
+        '200': 
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKey'
+        '400':
+          description: Invalid input
+        '404':
+          description: Not Found
+        '422':
+          description: Validation exception or missing fields
+    delete:
+      tags:
+        - apikey
+      summary: Revoke an api key
+      description: Revoke an api key 
+      operationId: revokeAPIKey
+      security:
+        - bearer-auth: [ ]
+      parameters:
+        - name: keyID
+          in: path
+          description: id or client id of api key to return
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+        '404':
+          description: API Key not found
   /v1/utilities/travel-address/encode:
     post:
       tags:
@@ -1920,6 +2103,49 @@ components:
         decoded:
           type: string
           description: The decoded travel address.
+    APIKey:
+      type: object
+      description: An complete APIKey representation
+      properties:
+        id:
+          type: string
+          format: ULID
+          description: The unique identifier of the API key
+        description:
+          type: string
+          description: A textual description to help users identity the API key
+        client_id:
+          type: string
+          description: The client id of the API key used for authentication
+        secret:
+          type: string
+          description: The client secret of the API key used for authentication; only shown on create.
+        last_seen:
+          type: string
+          format: date-time
+          description: The last timestamp that the API key was used for authentication
+        permissions:
+          type: array
+          items:
+            type: string
+        created:
+          type: string
+          format: date-time
+          description: The date and time when the API key was created.
+        modified:
+          type: string
+          format: date-time
+          description: The date and time when the API key was last modified.
+    APIKeyList:
+      type: object
+      description: A list of API key summaries
+      properties:
+        page:
+          $ref: '#/components/schemas/PageQuery'
+        api_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIKey'
   securitySchemes:
     bearer-auth:
       type: http

--- a/pkg/web/templates/openapi/openapi.yaml
+++ b/pkg/web/templates/openapi/openapi.yaml
@@ -1266,7 +1266,7 @@ paths:
       tags:
         - apikey
       summary: Create a new API Key
-      description: Request a new api key be generated with the specified description and permissions 
+      description: Request a new api key to be generated with the specified description and permissions 
       operationId: createAPIKey
       security:
         - bearer-auth: [ ]
@@ -2105,7 +2105,7 @@ components:
           description: The decoded travel address.
     APIKey:
       type: object
-      description: An complete APIKey representation
+      description: A complete APIKey representation
       properties:
         id:
           type: string


### PR DESCRIPTION
### Scope of changes

This PR fixes two stories:

1. SC-27115: ReplyTo is an empty ULID instead of null
2. SC-27144: Adds secure envelope metadata to envelope

I'd also like to reduce the amount of data sent in the LIST request for secure envelopes so we don't overwhelm the client with data. 

API Docs are also updated with the changes.

### Type of change

- [x] bug fix
- [x] new feature
- [x] documentation
- [x] other (api changes)

### Acceptance criteria

For the `GET /v1/transactions/:id/secure-envelopes/` list endpoint, I’d like to reduce the information that’s being sent back so that the response is more manageable. In the encrypted form I would remove the following fields:

1. payload 
2. encryption key 
3. hmac secret 
4. hmac 
5. original 

In the decrypted form I would remove:

1. identity
2. transaction
3. pending 
4. secure_envelope 

Would that break anything for the front end?

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.
- [ ] Empty reply_to returns `{"reply_to": null}` in json response
- [ ] Additional fields on Envelope are sufficient for the change requested


