### PR TITLE
Add revoke api key modal

### DIFF
--- a/pkg/web/static/js/apikeys.js
+++ b/pkg/web/static/js/apikeys.js
@@ -3,14 +3,14 @@ import { setSuccessToast } from "./utils.js";
 
 const apiKeysEP = '/v1/apikeys';
 const addApiKeyModal = document.getElementById('add_apikey_modal');
+const deleteApiKeyModal = document.getElementById('delete_key_modal');
 const closeApiKeyModal = document.getElementById('close-apikey-modal');
-const apiKeyModal = document.getElementById('apikey_modal');
 const addApiKeyForm = document.getElementById('new-apikey-form');
 const fullCheckbox = document.getElementById('full_access');
 const customAccess = document.getElementById('custom-access');
 const customCheckbox = document.querySelectorAll('.custom-access');
 
-// Reset API key form if user closes modal without submitting.
+// Reset create API key form if user closes modal without submitting.
 if (closeApiKeyModal) {
   closeApiKeyModal.addEventListener('click', () => {
     addApiKeyModal.close();
@@ -95,7 +95,7 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
   };
 
   if (e.detail.requestConfig.verb === 'delete' && e.detail.successful) {
-    apiKeyModal.close();
+    deleteApiKeyModal.close();
     setSuccessToast('Success! The API key has been revoked.');
   }
 });

--- a/pkg/web/static/js/apikeys.js
+++ b/pkg/web/static/js/apikeys.js
@@ -3,7 +3,7 @@ import { setSuccessToast } from "./utils.js";
 
 const apiKeysEP = '/v1/apikeys';
 const addApiKeyModal = document.getElementById('add_apikey_modal');
-const deleteApiKeyModal = document.getElementById('delete_key_modal');
+const revokeApiKeyModal = document.getElementById('revoke_key_modal');
 const closeApiKeyModal = document.getElementById('close-apikey-modal');
 const addApiKeyForm = document.getElementById('new-apikey-form');
 const fullCheckbox = document.getElementById('full_access');
@@ -95,7 +95,7 @@ document.body.addEventListener('htmx:afterSettle', (e) => {
   };
 
   if (e.detail.requestConfig.verb === 'delete' && e.detail.successful) {
-    deleteApiKeyModal.close();
+    revokeApiKeyModal.close();
     setSuccessToast('Success! The API key has been revoked.');
   }
 });

--- a/pkg/web/templates/apikeys.html
+++ b/pkg/web/templates/apikeys.html
@@ -21,7 +21,7 @@
 
 <!-- Target to display other api key management modals -->
 <dialog id="apikey_modal" class="modal"></dialog>
-<dialog id="delete_key_modal" class="modal"></dialog>
+<dialog id="revoke_key_modal" class="modal"></dialog>
 {{ end }}
 
 {{ define "appcode" }}

--- a/pkg/web/templates/apikeys.html
+++ b/pkg/web/templates/apikeys.html
@@ -21,6 +21,7 @@
 
 <!-- Target to display other api key management modals -->
 <dialog id="apikey_modal" class="modal"></dialog>
+<dialog id="delete_key_modal" class="modal"></dialog>
 {{ end }}
 
 {{ define "appcode" }}

--- a/pkg/web/templates/partials/apikey/apikey_delete.html
+++ b/pkg/web/templates/partials/apikey/apikey_delete.html
@@ -1,1 +1,1 @@
-<section hx-get="/v1/apikeys" hx-trigger="load"></section>
+<section id="apikeys" hx-get="/v1/apikeys" hx-trigger="load"></section>

--- a/pkg/web/templates/partials/apikey/apikey_detail.html
+++ b/pkg/web/templates/partials/apikey/apikey_detail.html
@@ -2,7 +2,7 @@
 <div class="modal-box">
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-xl">Revoke API Key</h1>
-    <button onclick="apikey_modal.close()" class="btn btn-sm btn-circle btn-ghost">
+    <button onclick="delete_key_modal.close()" class="btn btn-sm btn-circle btn-ghost">
       <i class="fa-solid fa-x"></i>
       <span class="sr-only">Close modal</span>
     </button>

--- a/pkg/web/templates/partials/apikey/apikey_detail.html
+++ b/pkg/web/templates/partials/apikey/apikey_detail.html
@@ -2,7 +2,7 @@
 <div class="modal-box">
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-xl">Revoke API Key</h1>
-    <button onclick="delete_key_modal.close()" class="btn btn-sm btn-circle btn-ghost">
+    <button onclick="revoke_key_modal.close()" class="btn btn-sm btn-circle btn-ghost">
       <i class="fa-solid fa-x"></i>
       <span class="sr-only">Close modal</span>
     </button>

--- a/pkg/web/templates/partials/apikey/apikey_list.html
+++ b/pkg/web/templates/partials/apikey/apikey_list.html
@@ -24,9 +24,9 @@
           <td>
             <button 
             type="button" 
-            onclick="delete_key_modal.showModal()" 
+            onclick="revoke_key_modal.showModal()" 
             hx-get="/v1/apikeys/{{ .ID }}" 
-            hx-target="#delete_key_modal" 
+            hx-target="#revoke_key_modal" 
             hx-swap="innerHTML" 
             class="btn btn-sm bg-warning text-white hover:bg-warning/80"
             >

--- a/pkg/web/templates/partials/apikey/apikey_list.html
+++ b/pkg/web/templates/partials/apikey/apikey_list.html
@@ -24,9 +24,9 @@
           <td>
             <button 
             type="button" 
-            onclick="apikey_modal.showModal()" 
+            onclick="delete_key_modal.showModal()" 
             hx-get="/v1/apikeys/{{ .ID }}" 
-            hx-target="#apikey_modal" 
+            hx-target="#delete_key_modal" 
             hx-swap="innerHTML" 
             class="btn btn-sm bg-warning text-white hover:bg-warning/80"
             >


### PR DESCRIPTION
### Scope of changes

This PR adds a separate modal to display the revoke api key modal to fix an issue where the modal didn't always close after a successful delete request.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/30767756?key=f0763b0465d356200cec0bb9e38ad71b

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


