### PR TITLE
Add index to input name to resolve data parsing error

### DIFF
--- a/pkg/web/static/js/transactionPreviewForm.js
+++ b/pkg/web/static/js/transactionPreviewForm.js
@@ -114,7 +114,6 @@ document.body.addEventListener('htmx:configRequest', (e) => {
   const repairTransactionEP = `/v1/transactions/${id}/repair`;
   if (e.detail.path === transactionAcceptEP && e.detail.verb === 'post' || e.detail.path === repairTransactionEP && e.detail.verb === 'post') {
     const params = e.detail.parameters;
-    console.log(params)
 
     let data = {
       identity: {

--- a/pkg/web/static/js/transactionPreviewForm.js
+++ b/pkg/web/static/js/transactionPreviewForm.js
@@ -114,6 +114,7 @@ document.body.addEventListener('htmx:configRequest', (e) => {
   const repairTransactionEP = `/v1/transactions/${id}/repair`;
   if (e.detail.path === transactionAcceptEP && e.detail.verb === 'post' || e.detail.path === repairTransactionEP && e.detail.verb === 'post') {
     const params = e.detail.parameters;
+    console.log(params)
 
     let data = {
       identity: {
@@ -128,7 +129,6 @@ document.body.addEventListener('htmx:configRequest', (e) => {
               }],
               nationalIdentification: {},
               dateAndPlaceOfBirth:{},
-              accountNumber: []
             },
           }],
         },
@@ -143,7 +143,6 @@ document.body.addEventListener('htmx:configRequest', (e) => {
               }],
               nationalIdentification: {},
               dateAndPlaceOfBirth:{},
-              accountNumber: []
             },
           }]
         },
@@ -151,7 +150,7 @@ document.body.addEventListener('htmx:configRequest', (e) => {
           originatingVASP: {
             legalPerson: {
               name: {
-                nameIdentifier: [{}]
+                nameIdentifier: []
               },
               geographicAddress: [{
                 addressLine: []
@@ -164,7 +163,7 @@ document.body.addEventListener('htmx:configRequest', (e) => {
           beneficiaryVASP: {
             legalPerson: {
               name: {
-                nameIdentifier: [{}]
+                nameIdentifier: []
               },
               geographicAddress: [{
                 addressLine: []
@@ -190,6 +189,7 @@ document.body.addEventListener('htmx:configRequest', (e) => {
     for (const key in params) {
       // Remove prefix from the key.
       const newKey = key.split('_').slice(2).join('_');
+      const indx = key.split('_')[3];
 
       switch (true) {
         // Set the transaction details.
@@ -220,10 +220,6 @@ document.body.addEventListener('htmx:configRequest', (e) => {
         case key.startsWith('originator_id_'):
           originatorPerson.nationalIdentification[newKey] = params[key];
           break;
-        // Set the originator account number.
-        case key.startsWith('acct_og_'):
-          originatorPerson.accountNumber.push(params[key]);
-          break;
         // Set the beneficiary name identifiers and name identifier type.
         case key.startsWith('id_bf_'):
           beneficiaryPerson.name.nameIdentifier[0][newKey] = params[key];
@@ -248,13 +244,9 @@ document.body.addEventListener('htmx:configRequest', (e) => {
         case key.startsWith('beneficiary_id_'):
           beneficiaryPerson.nationalIdentification[newKey] = params[key];
           break;
-        // Set the beneficiary account number.
-        case key.startsWith('acct_bf_'):
-          beneficiaryPerson.accountNumber.push(params[key]);
-          break;
         // Set the originating VASP name identifiers and name identifier type.
-        case key.startsWith('id_orig'):
-          originatingVASP.name.nameIdentifier[0][newKey] = params[key];
+        case key.startsWith('id_orig_legalPersonNameIdentifierType_'):
+          originatingVASP.name.nameIdentifier.push({ legalPersonName: params[`id_orig_legalPersonName_${indx}`], legalPersonNameIdentifierType: params[`id_orig_legalPersonNameIdentifierType_${indx}`] });
           break;
         // Set the originating VASP address line.
         case key.startsWith('address_orig'):
@@ -273,8 +265,8 @@ document.body.addEventListener('htmx:configRequest', (e) => {
           originatingVASP[newKey] = params[key];
           break;
         // Set the beneficiary VASP name identifiers and name identifier type.
-        case key.startsWith('id_benf'):
-          beneficiaryVASP.name.nameIdentifier[0][newKey] = params[key];
+        case key.startsWith('id_benf_legalPersonNameIdentifierType_'):          
+          beneficiaryVASP.name.nameIdentifier.push({ legalPersonName: params[`id_benf_legalPersonName_${indx}`], legalPersonNameIdentifierType: params[`id_benf_legalPersonNameIdentifierType_${indx}`] });
           break;
         // Set the beneficiary VASP address line.
         case key.startsWith('address_benf'):

--- a/pkg/web/templates/partials/transaction/transaction_accept.html
+++ b/pkg/web/templates/partials/transaction/transaction_accept.html
@@ -32,7 +32,7 @@
           </div>
           <div>
             <label for="asset_type" class="label-style">Asset Type</label>
-            <input type="text" id="asset_type" name="env_transaction_asset_type" value="{{ .Pending.Transaction.AssetType }}"
+            <input type="text" id="asset_type" name="env_transaction_assetType" value="{{ .Pending.Transaction.AssetType }}"
               class="input-style" />
           </div>
           <div>
@@ -183,13 +183,6 @@
           <input type="hidden" class="originator_id_country_of_issue" value="" />
         </div>
         {{ end }}
-
-        {{ range .Identity.Originator.AccountNumbers }}
-        <div>
-          <label for="orig_account_numbers" class="label-style">Account Number</label>
-          <input type="text" id="orig_account_numbers" name="acct_og_account_number" value="{{ . }}" class="input-style" />
-        </div>
-        {{ end }}
       </div>
       {{ else }}
       <div class="my-5">
@@ -273,11 +266,6 @@
           <label for="originator_id_country_of_issue" class="label-style">Country of Issue</label>
           <select id="originator_id_country_of_issue" name="originator_id_countryOfIssue" class="countries"></select>
           <input type="hidden" class="originator_id_country_of_issue" value="" />
-        </div>
-      
-        <div>
-          <label for="orig_account_numbers" class="label-style">Account Number</label>
-          <input type="text" id="orig_account_numbers" name="acct_og_accountNumber" value="" class="input-style" />
         </div>
       </div>
       {{ end }}
@@ -419,13 +407,6 @@
         </div>
         {{ end }}
 
-        {{ range .Identity.Beneficiary.AccountNumbers }}
-        <div>
-          <label for="benf_account_numbers" class="label-style">Account Number</label>
-          <input type="text" id="benf_account_numbers" name="acct_bf_accountNumber" value="{{ . }}" class="input-style" />
-        </div>
-        {{ end }}
-
         {{ else }}
         <div class="my-5">
           <div class="grid gap-6 my-4 md:grid-cols-2">
@@ -512,10 +493,6 @@
             <input type="hidden" class="beneficiary_id_country_of_issue" value="" />
           </div>
         
-          <div>
-            <label for="benf_account_numbers" class="label-style">Account Number</label>
-            <input type="text" id="benf_account_numbers" name="acct_bf_accountNumber" value="" class="input-style" />
-          </div>
         </div>
         {{ end }}
       </div>
@@ -527,18 +504,18 @@
           {{ $originatingVasp := .Identity.OriginatingVasp.OriginatingVasp.Person.LegalPerson }}
           {{ $originatingLegalPerson := $originatingVasp.Name }}
 
-        {{ range $originatingLegalPerson.NameIdentifiers }}
+        {{ range $index, $originatingVaspName := $originatingLegalPerson.NameIdentifiers }}
         <div class="grid gap-6 my-4 md:grid-cols-2">
           <div>
-            <label for="orig_vasp_legal_person_name" class="label-style">Legal Person Name</label>
-            <input type="text" id="orig_vasp_legal_person_name" name="id_orig_legalPersonName"
+            <label for="orig_vasp_legal_person_name_{{ $index }}" class="label-style">Legal Person Name</label>
+            <input type="text" id="orig_vasp_legal_person_name_{{ $index }}" name="id_orig_legalPersonName_{{ $index }}"
               value="{{ .LegalPersonName }}" class="input-style" />
           </div>
           <div>
-            <label for="orig_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier Type</label>
-            <select id="orig_vasp_legal_person_name_identifier_type" name="id_orig_legalPersonNameIdentifierType"
+            <label for="orig_vasp_legal_person_name_identifier_type_{{ $index }}" class="label-style">Legal Person Name Identifier Type</label>
+            <select id="orig_vasp_legal_person_name_identifier_type_{{ $index }}" name="id_orig_legalPersonNameIdentifierType_{{ $index }}"
               class="identifier-types"></select>
-            <input type="hidden" class="orig_vasp_legal_person_name_identifier_type"
+            <input type="hidden" class="orig_vasp_legal_person_name_identifier_type_{{ $index }}"
               value="{{ .LegalPersonNameIdentifierType }}" data-id="legal-person-name-type" />
           </div>
         </div>
@@ -690,19 +667,20 @@
         {{ if .Identity.BeneficiaryVasp }}
           {{ $beneficiaryVasp := .Identity.BeneficiaryVasp.BeneficiaryVasp.Person.LegalPerson }}
 
-        {{ range $beneficiaryVasp.Name.NameIdentifiers }}
+          {{ range $index, $beneficiaryVaspName := $beneficiaryVasp.Name.NameIdentifiers }}
         <div class="grid gap-6 my-4 md:grid-cols-2">
           <div>
-            <label for="benf_vasp_legal_person_name" class="label-style">Name Identifier</label>
-            <input type="text" id="benf_vasp_legal_person_name" name="id_benf_legalPersonName"
+            <label for="benf_vasp_legal_person_name_{{ $index }}" class="label-style">Name Identifier</label>
+            <input type="text" id="benf_vasp_legal_person_name_{{ $index }}" name="id_benf_legalPersonName_{{ $index }}"
               value="{{ .LegalPersonName }}" class="input-style" />
           </div>
           <div>
-            <label for="benf_vasp_legal_person_name_identifier_type" class="label-style">Legal Person Name Identifier
-              Type</label>
-            <select id="benf_vasp_legal_person_name_identifier_type" name="id_benf_legalPersonNameIdentifierType"
+            <label for="benf_vasp_legal_person_name_identifier_type_{{ $index }}" class="label-style">
+              Legal Person Name Identifier Type
+            </label>
+            <select id="benf_vasp_legal_person_name_identifier_type_{{ $index}}" name="id_benf_legalPersonNameIdentifierType_{{ $index }}"
               class="identifier-types"></select>
-            <input type="hidden" class="benf_vasp_legal_person_name_identifier_type"
+            <input type="hidden" class="benf_vasp_legal_person_name_identifier_type_{{ $index }}"
               value="{{ .LegalPersonNameIdentifierType }}" data-id="legal-person-name-type" />
           </div>
         </div>

--- a/pkg/web/templates/transactions_accept.html
+++ b/pkg/web/templates/transactions_accept.html
@@ -19,5 +19,4 @@
 
 {{ define "appcode" }}
 <script type="module" src="/static/js/transactionPreviewForm.js"></script>
-<script type="module" src="/static/js/transactionAccept.js"></script>
 {{ end }}


### PR DESCRIPTION
### Scope of changes

This PR adds an index to prevent duplicate input names in the Originating VASP and Beneficiary VASP name sections of the transaction accept preview form. The change also resolved an issue causing the incorrect name identifier type to display in the UI.

`AccountNumber` has been removed from the form to resolve another parsing error that occurred while attempting to verify the name and name identifier type changes work.


### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


