### PR TITLE
Save Secure Envelopes during Sunrise

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sendgrid/sendgrid-go v3.16.0+incompatible
 	github.com/stretchr/testify v1.9.0
 	github.com/trisacrypto/directory v1.8.1
-	github.com/trisacrypto/trisa v1.4.1
+	github.com/trisacrypto/trisa v1.5.0
 	github.com/urfave/cli/v2 v2.27.5
 	golang.org/x/crypto v0.29.0
 	golang.org/x/text v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/trisacrypto/directory v1.8.1 h1:DzBNkgF2imT5oB5lSUF9aFTt7FDBywVSS82mM
 github.com/trisacrypto/directory v1.8.1/go.mod h1:/Np2wV158WgATrvTv8KCTNoZ13SRHLbiDds1Dl+Mo04=
 github.com/trisacrypto/lei v1.0.0 h1:LKrwOgYjW+ljzBmN6hGgBbGFAktoRmovyY7ZYZB5/uI=
 github.com/trisacrypto/lei v1.0.0/go.mod h1:OsJZIYPShoSETOphRXAIlHwwesIsvo5PPpEemp/wGZI=
-github.com/trisacrypto/trisa v1.4.1 h1:n28FfqNklHvHpGT00NSqNyMHklWBRJD8QV9PbBWYRQY=
-github.com/trisacrypto/trisa v1.4.1/go.mod h1:zZCYwaoipb7nvSbKiJDjDf9gPNJKYWMk1WoPXcVkERY=
+github.com/trisacrypto/trisa v1.5.0 h1:uf3IRfNzHFjLEJnKlIHqxM8Mylmd2spmDUoY/E2BySc=
+github.com/trisacrypto/trisa v1.5.0/go.mod h1:zZCYwaoipb7nvSbKiJDjDf9gPNJKYWMk1WoPXcVkERY=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=

--- a/pkg/postman/errors.go
+++ b/pkg/postman/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrNoCounterpartyInfo = errors.New("no counterparty info available on packet")
 	ErrNoUnsealingKey     = errors.New("cannot open incoming envelope without unsealing key")
 	ErrNoSealingKey       = errors.New("cannot seal outgoing envelope without sealing key")
+	ErrNoContacts         = errors.New("no contacts are associated with counterparty, cannot send sunrise messages")
 )

--- a/pkg/postman/errors.go
+++ b/pkg/postman/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrNoUnsealingKey     = errors.New("cannot open incoming envelope without unsealing key")
 	ErrNoSealingKey       = errors.New("cannot seal outgoing envelope without sealing key")
 	ErrNoContacts         = errors.New("no contacts are associated with counterparty, cannot send sunrise messages")
+	ErrNoMessages         = errors.New("no messages sent with the sunrise packet, cannot create sunrise pending ")
 )

--- a/pkg/postman/sunrise.go
+++ b/pkg/postman/sunrise.go
@@ -1,0 +1,92 @@
+package postman
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/trisacrypto/envoy/pkg/emails"
+	"github.com/trisacrypto/envoy/pkg/store/models"
+	"github.com/trisacrypto/envoy/pkg/sunrise"
+	trisa "github.com/trisacrypto/trisa/pkg/trisa/api/v1beta1"
+)
+
+const defaultSunriseExpiration = 14 * 24 * time.Hour
+
+type SunrisePacket struct {
+	Packet
+}
+
+func SendSunrise(envelopeID uuid.UUID, payload *trisa.Payload) (packet *SunrisePacket, err error) {
+	var parent *Packet
+	if parent, err = Send(envelopeID, payload, trisa.TransferStarted); err != nil {
+		return nil, err
+	}
+
+	packet = &SunrisePacket{
+		Packet: *parent,
+	}
+
+	// Add parent to submessages
+	packet.In.packet = &packet.Packet
+	packet.Out.packet = &packet.Packet
+
+	return packet, nil
+}
+
+func (s *SunrisePacket) Contacts() (contacts []*models.Contact, err error) {
+	if contacts, err = s.Counterparty.Contacts(); err != nil {
+		return nil, err
+	}
+
+	if len(contacts) == 0 {
+		return nil, ErrNoContacts
+	}
+
+	return contacts, nil
+}
+
+func (s *SunrisePacket) SendEmail(contact *models.Contact, invite emails.SunriseInviteData) (err error) {
+	// Create a sunrise record for database storage
+	record := &models.Sunrise{
+		EnvelopeID: uuid.MustParse(s.EnvelopeID()),
+		Email:      contact.Email,
+		Expiration: time.Now().Add(defaultSunriseExpiration),
+		Status:     models.StatusDraft,
+	}
+
+	// Create the ID in the database of the sunrise record.
+	if err = s.DB.CreateSunrise(record); err != nil {
+		return err
+	}
+
+	// Create the HMAC verification token for the contact
+	verification := sunrise.NewToken(record.ID, record.Expiration)
+
+	// Sign the verification token
+	if invite.Token, record.Signature, err = verification.Sign(); err != nil {
+		return err
+	}
+
+	// Send the email to the contact
+	var email *emails.Email
+	if email, err = emails.NewSunriseInvite(contact.Address().String(), invite); err != nil {
+		return err
+	}
+
+	if err = email.Send(); err != nil {
+		return err
+	}
+
+	// Update the sunrise record in the database with the token and sent on timestamp
+	record.SentOn = sql.NullTime{Valid: true, Time: time.Now()}
+	record.Status = models.StatusPending
+
+	if err = s.DB.UpdateSunrise(record); err != nil {
+		return err
+	}
+
+	s.Log.Info().Str("email", contact.Email).Msg("sunrise verification token sent")
+	return nil
+}

--- a/pkg/postman/sunrise.go
+++ b/pkg/postman/sunrise.go
@@ -2,22 +2,32 @@ package postman
 
 import (
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trisacrypto/envoy/pkg/emails"
 	"github.com/trisacrypto/envoy/pkg/store/models"
 	"github.com/trisacrypto/envoy/pkg/sunrise"
 	trisa "github.com/trisacrypto/trisa/pkg/trisa/api/v1beta1"
+	generic "github.com/trisacrypto/trisa/pkg/trisa/data/generic/v1beta1"
+	"github.com/trisacrypto/trisa/pkg/trisa/envelope"
+	"github.com/trisacrypto/trisa/pkg/trisa/keys"
 )
 
 const defaultSunriseExpiration = 14 * 24 * time.Hour
 
 type SunrisePacket struct {
 	Packet
+	Messages []*generic.SunriseMessage
+	payload  *trisa.Payload
 }
 
+// Initiates a Sunrise packet for handling interactions between secure envelopes and
+// sending messages via email to compliance contacts that they have a new compliance
+// message for review.
 func SendSunrise(envelopeID uuid.UUID, payload *trisa.Payload) (packet *SunrisePacket, err error) {
 	var parent *Packet
 	if parent, err = Send(envelopeID, payload, trisa.TransferStarted); err != nil {
@@ -32,9 +42,12 @@ func SendSunrise(envelopeID uuid.UUID, payload *trisa.Payload) (packet *SunriseP
 	packet.In.packet = &packet.Packet
 	packet.Out.packet = &packet.Packet
 
+	// Keep track of the original payload
+	packet.payload = payload
 	return packet, nil
 }
 
+// Returns the email contacts of the compliance officers associated with the counterparty.
 func (s *SunrisePacket) Contacts() (contacts []*models.Contact, err error) {
 	if contacts, err = s.Counterparty.Contacts(); err != nil {
 		return nil, err
@@ -47,6 +60,7 @@ func (s *SunrisePacket) Contacts() (contacts []*models.Contact, err error) {
 	return contacts, nil
 }
 
+// Send a sunrise invitation email to the contact and create a verification token.
 func (s *SunrisePacket) SendEmail(contact *models.Contact, invite emails.SunriseInviteData) (err error) {
 	// Create a sunrise record for database storage
 	record := &models.Sunrise{
@@ -87,6 +101,151 @@ func (s *SunrisePacket) SendEmail(contact *models.Contact, invite emails.Sunrise
 		return err
 	}
 
+	// Store the message info for the Sunrise "reply" message
+	s.Messages = append(s.Messages, &generic.SunriseMessage{
+		Recipient:      contact.Name,
+		Email:          contact.Email,
+		Channel:        "email",
+		SentAt:         record.SentOn.Time.Format(time.RFC3339),
+		ReplyNotBefore: record.Expiration.Format(time.RFC3339),
+	})
+
 	s.Log.Info().Str("email", contact.Email).Msg("sunrise verification token sent")
+	return nil
+}
+
+// Creates the "reply" pending message for the sunrise messages that were sent.
+func (s *SunrisePacket) Pending() (err error) {
+	if len(s.Messages) == 0 {
+		return ErrNoMessages
+	}
+
+	// Fetch the original payload from the outgoing message
+	payload := &trisa.Payload{
+		Identity:   s.payload.Identity,
+		SentAt:     s.payload.SentAt,
+		ReceivedAt: s.payload.ReceivedAt,
+	}
+
+	transaction := &generic.Sunrise{
+		EnvelopeId:   s.EnvelopeID(),
+		Counterparty: s.Counterparty.Name,
+		Messages:     s.Messages,
+	}
+
+	transaction.Transaction = &generic.Transaction{}
+	if err = s.payload.Transaction.UnmarshalTo(transaction.Transaction); err != nil {
+		return fmt.Errorf("could not unmarshal original transaction: %w", err)
+	}
+
+	if payload.Transaction, err = anypb.New(transaction); err != nil {
+		return fmt.Errorf("could not wrap sunrise transaction: %w", err)
+	}
+
+	opts := []envelope.Option{
+		envelope.WithEnvelopeID(s.EnvelopeID()),
+		envelope.WithTransferState(trisa.TransferPending),
+	}
+
+	if s.In.Envelope, err = envelope.New(payload, opts...); err != nil {
+		return fmt.Errorf("could not create envelope for sunrise messages: %w", err)
+	}
+
+	return nil
+}
+
+// Encrypts the the "incoming" sunrise message for secure storage in the database with
+// the specifrified storage key. and also passes this key to the "outgoing" secure
+// envelope for secure encryption when that envlepe is turned into a model.
+func (s *SunrisePacket) Seal(storageKey keys.PublicKey) (err error) {
+	if storageKey == nil {
+		return ErrNoSealingKey
+	}
+
+	// Ensure the outgoing message has the same encryption key as the incoming!
+	s.Out.StorageKey = storageKey
+	if s.Out.Envelope, _, err = s.Out.Envelope.Encrypt(); err != nil {
+		return fmt.Errorf("could not encrypt outgoing envelope: %w", err)
+	}
+
+	// The sunrise incoming message must be encrypted for local storage in the database
+	// since it is not encrypted by the "sender" (it's just a record of sent emails).
+	if !s.In.Envelope.IsError() {
+		if s.In.Envelope, _, err = s.In.Envelope.Encrypt(); err != nil {
+			return fmt.Errorf("could not encrypt sunrise message: %w", err)
+		}
+
+		if s.In.Envelope, _, err = s.In.Envelope.Seal(envelope.WithSealingKey(storageKey)); err != nil {
+			return fmt.Errorf("could not seal sunrise message: %w", err)
+		}
+
+		// Store the encrypted and sealed envelope as the "original" message, which will
+		// be saved in the databaser when s.In.Model() is called.
+		s.In.original = s.In.Envelope.Proto()
+	}
+
+	return nil
+}
+
+// This method creates the pending message to represent the "incoming" response; e.g. a
+// record of the email messages that were sent and then encrypts both the outgoing and
+// incoming messages using the storage key before saving the envelopes in the database.
+// Finally, this method updates the transaction state and refreshes the local
+// transaction so that the information is visible to the API.
+func (s *SunrisePacket) Save(storageKey keys.PublicKey) (err error) {
+	// Ensure that we have a counterparty
+	if err = s.ResolveCounterparty(); err != nil {
+		return err
+	}
+
+	// Add the counterparty to the transaction
+	if err = s.DB.AddCounterparty(s.Counterparty); err != nil {
+		return fmt.Errorf("could not associate counterparty with transaction: %w", err)
+	}
+
+	// Refresh the transaction to get the counterparty info before update.
+	if err = s.RefreshTransaction(); err != nil {
+		return err
+	}
+
+	// Add the transaction details from the payload of the outgoing message
+	if payload := s.Out.Envelope.FindPayload(); payload != nil {
+		s.Transaction = TransactionFromPayload(payload)
+	}
+
+	// Set transaction values
+	s.Transaction.Source = models.SourceLocal
+	s.Transaction.Status = models.StatusPending
+	s.Transaction.LastUpdate = sql.NullTime{Valid: true, Time: time.Now()}
+
+	// Update the transaction in the database
+	if err = s.DB.Update(s.Transaction); err != nil {
+		return fmt.Errorf("could not update transaction in database: %w", err)
+	}
+
+	// Create the incoming secure envelope with the sunrise message
+	if err = s.Pending(); err != nil {
+		return err
+	}
+
+	// Seal the incoming and outgoing messages with the storage key
+	if err = s.Seal(storageKey); err != nil {
+		return err
+	}
+
+	// Add envelopes to the database
+	if err = s.DB.AddEnvelope(s.Out.Model()); err != nil {
+		return fmt.Errorf("could not store outgoing sunrise message: %w", err)
+	}
+
+	if err = s.DB.AddEnvelope(s.In.Model()); err != nil {
+		return fmt.Errorf("could not store incoming sunrise message: %w", err)
+	}
+
+	// Refresh to respond with the latest transaction info to the API request.
+	if err = s.RefreshTransaction(); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/postman/sunrise.go
+++ b/pkg/postman/sunrise.go
@@ -164,7 +164,8 @@ func (s *SunrisePacket) Seal(storageKey keys.PublicKey) (err error) {
 
 	// Ensure the outgoing message has the same encryption key as the incoming!
 	s.Out.StorageKey = storageKey
-	if s.Out.Envelope, _, err = s.Out.Envelope.Encrypt(); err != nil {
+	s.Out.SealingKey = storageKey
+	if _, err = s.Out.Seal(); err != nil {
 		return fmt.Errorf("could not encrypt outgoing envelope: %w", err)
 	}
 
@@ -180,7 +181,7 @@ func (s *SunrisePacket) Seal(storageKey keys.PublicKey) (err error) {
 		}
 
 		// Store the encrypted and sealed envelope as the "original" message, which will
-		// be saved in the databaser when s.In.Model() is called.
+		// be saved in the database when s.In.Model() is called.
 		s.In.original = s.In.Envelope.Proto()
 	}
 

--- a/pkg/trisa/validate.go
+++ b/pkg/trisa/validate.go
@@ -40,6 +40,7 @@ var validIdentityTypes = map[string]struct{}{
 var validTransactionTypes = map[string]struct{}{
 	"type.googleapis.com/trisa.data.generic.v1beta1.Transaction": {},
 	"type.googleapis.com/trisa.data.generic.v1beta1.Pending":     {},
+	"type.googleapis.com/trisa.data.generic.v1beta1.Sunrise":     {},
 }
 
 // Validates an incoming TRISA payload, ensuring that it has all required fields and

--- a/pkg/web/api/v1/transaction.go
+++ b/pkg/web/api/v1/transaction.go
@@ -391,7 +391,6 @@ func NewEnvelope(model *models.SecureEnvelope, env *envelope.Envelope) (out *Env
 		Remote:             model.Remote.String,
 		Timestamp:          model.Timestamp,
 		PublicKeySignature: model.PublicKey.String,
-		TransferState:      env.TransferState().String(),
 	}
 
 	if model.ReplyTo.Valid {
@@ -409,6 +408,7 @@ func NewEnvelope(model *models.SecureEnvelope, env *envelope.Envelope) (out *Env
 	}
 
 	// Use the decrypted envelope to populate the payload.
+	out.TransferState = env.TransferState().String()
 	switch state := env.State(); state {
 	case envelope.Error:
 		out.IsError = true
@@ -468,6 +468,7 @@ func NewEnvelopeList(page *models.SecureEnvelopePage, envelopes []*envelope.Enve
 
 	out = &EnvelopesList{
 		Page:               &PageQuery{},
+		IsDecrypted:        true,
 		DecryptedEnvelopes: make([]*Envelope, 0, len(page.Envelopes)),
 	}
 
@@ -482,6 +483,7 @@ func NewEnvelopeList(page *models.SecureEnvelopePage, envelopes []*envelope.Enve
 		env.Identity = nil
 		env.Transaction = nil
 		env.Pending = nil
+		env.Sunrise = nil
 		env.SecureEnvelope = nil
 
 		out.DecryptedEnvelopes = append(out.DecryptedEnvelopes, env)

--- a/pkg/web/api/v1/transaction.go
+++ b/pkg/web/api/v1/transaction.go
@@ -84,6 +84,7 @@ type Envelope struct {
 	Identity           *ivms101.IdentityPayload `json:"identity,omitempty"`
 	Transaction        *generic.Transaction     `json:"transaction,omitempty"`
 	Pending            *generic.Pending         `json:"pending,omitempty"`
+	Sunrise            *generic.Sunrise         `json:"sunrise,omitempty"`
 	SentAt             *time.Time               `json:"sent_at"`
 	ReceivedAt         *time.Time               `json:"received_at,omitempty"`
 	Timestamp          time.Time                `json:"timestamp,omitempty"`
@@ -438,6 +439,11 @@ func NewEnvelope(model *models.SecureEnvelope, env *envelope.Envelope) (out *Env
 	case "type.googleapis.com/trisa.data.generic.v1beta1.Pending":
 		out.Pending = &generic.Pending{}
 		if err = payload.Transaction.UnmarshalTo(out.Pending); err != nil {
+			return nil, err
+		}
+	case "type.googleapis.com/trisa.data.generic.v1beta1.Sunrise":
+		out.Sunrise = &generic.Sunrise{}
+		if err = payload.Transaction.UnmarshalTo(out.Sunrise); err != nil {
 			return nil, err
 		}
 	default:

--- a/pkg/webhook/api.go
+++ b/pkg/webhook/api.go
@@ -39,6 +39,7 @@ type Payload struct {
 	Identity    *ivms101.IdentityPayload `json:"identity"`
 	Pending     *generic.Pending         `json:"pending,omitempty"`
 	Transaction *generic.Transaction     `json:"transaction,omitempty"`
+	Sunrise     *generic.Sunrise         `json:"sunrise,omitempty"`
 	SentAt      string                   `json:"sent_at"`
 	ReceivedAt  string                   `json:"received_at,omitempty"`
 }
@@ -56,6 +57,7 @@ type Reply struct {
 const (
 	transactionPBType = "type.googleapis.com/trisa.data.generic.v1beta1.Transaction"
 	pendingPBType     = "type.googleapis.com/trisa.data.generic.v1beta1.Pending"
+	sunrisePBType     = "type.googleapis.com/trisa.data.generic.v1beta1.Sunrise"
 )
 
 // Add a TRISA protocol buffer payload to the webhook request, unmarshaling it into its
@@ -88,6 +90,11 @@ func (r *Request) AddPayload(payload *trisa.Payload) (err error) {
 		r.Payload.Pending = &generic.Pending{}
 		if err = payload.Transaction.UnmarshalTo(r.Payload.Pending); err != nil {
 			return fmt.Errorf("could not unmarshal pending payload: %s", err)
+		}
+	case sunrisePBType:
+		r.Payload.Sunrise = &generic.Sunrise{}
+		if err = payload.Transaction.UnmarshalTo(r.Payload.Sunrise); err != nil {
+			return fmt.Errorf("could not unmarshal sunrise payload: %s", err)
 		}
 	default:
 		return fmt.Errorf("unknown transaction type %q", payload.Transaction.TypeUrl)


### PR DESCRIPTION
### Scope of changes

Ensures Sunrise Secure Envelopes are saved so that they can be viewed on the accept/reject page. It also implements the Sunrise specific postman features.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation