### PR TITLE
Sunrise Authentication

### DIFF
--- a/pkg/web/auth/claims.go
+++ b/pkg/web/auth/claims.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/trisacrypto/envoy/pkg/store/models"
+	"github.com/trisacrypto/envoy/pkg/web/auth/permissions"
 	"github.com/trisacrypto/envoy/pkg/web/gravatar"
 
 	jwt "github.com/golang-jwt/jwt/v4"
@@ -26,8 +27,9 @@ type Claims struct {
 type SubjectType rune
 
 const (
-	SubjectUser   = SubjectType('u')
-	SubjectAPIKey = SubjectType('k')
+	SubjectUser    = SubjectType('u')
+	SubjectAPIKey  = SubjectType('k')
+	SubjectSunrise = SubjectType('s')
 )
 
 var organization string
@@ -38,6 +40,8 @@ func NewClaims(ctx context.Context, model any) (*Claims, error) {
 		return NewClaimsForUser(ctx, t)
 	case *models.APIKey:
 		return NewClaimsForAPIClient(ctx, t)
+	case *models.Sunrise:
+		return NewClaimsForSunrise(ctx, t)
 	default:
 		return nil, fmt.Errorf("unknown model type %T: cannot create claims", t)
 	}
@@ -69,6 +73,16 @@ func NewClaimsForAPIClient(ctx context.Context, key *models.APIKey) (claims *Cla
 	}
 
 	claims.SetSubjectID(SubjectAPIKey, key.ID)
+	return claims, nil
+}
+
+func NewClaimsForSunrise(ctx context.Context, model *models.Sunrise) (claims *Claims, err error) {
+	claims = &Claims{
+		Email:       model.Email,
+		Permissions: []string{permissions.TravelRuleView.String()},
+	}
+
+	claims.SetSubjectID(SubjectSunrise, model.ID)
 	return claims, nil
 }
 

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -116,7 +116,7 @@ func (s *Server) setupRoutes() (err error) {
 	sunrise := s.router.Group("/sunrise", s.SunriseEnabled())
 	{
 		sunrise.GET("/verify", s.VerifySunriseUser)
-		sunrise.GET("/review", s.SunriseMessagePreview)
+		sunrise.GET("/review", authenticate, authorize(permiss.TravelRuleView), s.SunriseMessagePreview)
 		sunrise.GET("/message", authenticate, authorize(permiss.TravelRuleManage), s.SendMessageForm)
 	}
 


### PR DESCRIPTION
### Scope of changes

After sunrise verification an authentication cookie is set with an access code that contains a sunrise subject and the travel rule view permission. This enables the `/sunrise/review` route which is now authenticated and requires that permission. The cookie will also give us the ID of the secure envelope to load. 

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation