### PR TITLE
Do not allow Sunrise access to Envoy pages

### DIFF
--- a/pkg/web/auth/claims.go
+++ b/pkg/web/auth/claims.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/trisacrypto/envoy/pkg/store/models"
-	"github.com/trisacrypto/envoy/pkg/web/auth/permissions"
 	"github.com/trisacrypto/envoy/pkg/web/gravatar"
 
 	jwt "github.com/golang-jwt/jwt/v4"
@@ -79,7 +78,7 @@ func NewClaimsForAPIClient(ctx context.Context, key *models.APIKey) (claims *Cla
 func NewClaimsForSunrise(ctx context.Context, model *models.Sunrise) (claims *Claims, err error) {
 	claims = &Claims{
 		Email:       model.Email,
-		Permissions: []string{permissions.TravelRuleView.String()},
+		Permissions: nil,
 	}
 
 	claims.SetSubjectID(SubjectSunrise, model.ID)
@@ -94,6 +93,10 @@ func (c Claims) SubjectID() (SubjectType, ulid.ULID, error) {
 	sub := SubjectType(c.Subject[0])
 	id, err := ulid.Parse(c.Subject[1:])
 	return sub, id, err
+}
+
+func (c Claims) SubjectType() SubjectType {
+	return SubjectType(c.Subject[0])
 }
 
 func (c Claims) HasPermission(required string) bool {

--- a/pkg/web/auth/middleware.go
+++ b/pkg/web/auth/middleware.go
@@ -46,6 +46,12 @@ func Authenticate(issuer *ClaimsIssuer) gin.HandlerFunc {
 			return nil, ErrAuthRequired
 		}
 
+		// Do not allow sunrise subjects to be authenticated
+		if claims.SubjectType() == SubjectSunrise {
+			log.Debug().Msg("forbidding sunrise subject")
+			return nil, ErrAuthRequired
+		}
+
 		return claims, nil
 	}
 

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -83,6 +83,7 @@ func (s *Server) setupRoutes() (err error) {
 
 	// Authentication Middleware
 	authenticate := auth.Authenticate(s.issuer)
+	sunriseAuth := s.SunriseAuthenticate(s.issuer)
 
 	// Authorization Helper
 	authorize := func(permissions ...permiss.Permission) gin.HandlerFunc {
@@ -115,8 +116,13 @@ func (s *Server) setupRoutes() (err error) {
 	// Sunrise Routes (can be disabled by the middleware)
 	sunrise := s.router.Group("/sunrise", s.SunriseEnabled())
 	{
+		// Logs in a sunrise user to allow the external user to be sunrise authenticated.
 		sunrise.GET("/verify", s.VerifySunriseUser)
-		sunrise.GET("/review", authenticate, authorize(permiss.TravelRuleView), s.SunriseMessageReview)
+
+		// The review form for external sunrise users.
+		sunrise.GET("/review", sunriseAuth, s.SunriseMessageReview)
+
+		// The send sunrise message form for authenticated envoy users.
 		sunrise.GET("/message", authenticate, authorize(permiss.TravelRuleManage), s.SendMessageForm)
 	}
 

--- a/pkg/web/templates/components/sunrise_header.html
+++ b/pkg/web/templates/components/sunrise_header.html
@@ -3,7 +3,7 @@
   <nav class="navbar shadow-md">
     <div class="navbar-start my-2">
       <!-- TODO: Add copy about joining the TRISA network to the login page? -->
-      <a href="/">
+      <a href="https://trisa.io">
         <img src="/static/envoy-logo.webp" alt="Envoy Logo" class="w-48" />
       </a>
     </div>


### PR DESCRIPTION
### Scope of changes

Ensures that external sunrise users cannot access the main Envoy pages.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation