### PR TITLE
Document Counterparty Travel Address API

### DIFF
--- a/pkg/trisa/peers/info.go
+++ b/pkg/trisa/peers/info.go
@@ -35,15 +35,20 @@ func (i *Info) Validate() error {
 
 // Returns a counterparty data structure for API purposes.
 func (i *Info) Counterparty() *api.Counterparty {
-	return &api.Counterparty{
+	cp := &api.Counterparty{
 		DirectoryID:         i.ID,
 		RegisteredDirectory: i.RegisteredDirectory,
 		CommonName:          i.CommonName,
 		Endpoint:            i.Endpoint,
 		Name:                i.Name,
 		Country:             i.Country,
-		VerifiedOn:          i.VerifiedOn,
 	}
+
+	if !i.VerifiedOn.IsZero() {
+		cp.VerifiedOn = &i.VerifiedOn
+	}
+
+	return cp
 }
 
 // Returns a counterparty model data structure for TRISA interactions

--- a/pkg/web/templates/openapi/openapi.json
+++ b/pkg/web/templates/openapi/openapi.json
@@ -722,7 +722,7 @@
             "enum": [
               "trisa",
               "trp",
-              "email"
+              "sunrise"
             ],
             "description": "the travel rule protocol used to connect to the counterparty with.",
             "example": "trisa"
@@ -743,7 +743,7 @@
             "type": "string",
             "format": "TravelAddress",
             "description": "The counterparty travel address that allows the user to identify which counterparty to use in a transfer.",
-            "example": "taYgWCfsnPN8hsqUAZWm4TW7WrHU5qZT3GiBPpfSApGSqoPMH1D6kiNRzST5Gz"
+            "example": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv"
           },
           "name": {
             "type": "string",
@@ -845,7 +845,7 @@
           "protocol": "trisa",
           "common_name": "api.alice.vaspbot.net",
           "endpoint": "api.alice.vaspbot.net:443",
-          "travel_address": "taYgWCfsnPN8hsqUAZWm4TW7WrHU5qZT3GiBPpfSApGSqoPMH1D6kiNRzST5Gz",
+          "travel_address": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv",
           "name": "AliceCoin",
           "website": "https://alice.vaspbot.net",
           "country": "GB",
@@ -1017,7 +1017,7 @@
             "enum": [
               "trisa",
               "trp",
-              "email"
+              "sunrise"
             ],
             "description": "the travel rule protocol used to connect to the counterparty with, used to filter the returned list.",
             "example": "trisa"
@@ -1027,6 +1027,12 @@
             "format": "url",
             "description": "the URL endpoint to connect to using the travel rule protocol.",
             "example": "api.alice.vaspbot.net:443"
+          },
+          "travel_address": {
+            "type": "string",
+            "format": "TravelAddress",
+            "description": "the travel address to address the counterparty with using TRP/TRISA (empty for sunrise protocol)",
+            "example": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv"
           },
           "name": {
             "type": "string",
@@ -1057,6 +1063,7 @@
           "source": "gds",
           "protocol": "trisa",
           "endpoint": "api.alice.vaspbot.net:443",
+          "travel_address": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv",
           "name": "AliceCoin",
           "website": "https://alice.vaspbot.net",
           "country": "GB",
@@ -1082,6 +1089,7 @@
                 "source": "gds",
                 "protocol": "trisa",
                 "endpoint": "api.alice.vaspbot.net:443",
+                "travel_address": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv",
                 "name": "AliceCoin",
                 "website": "https://alice.vaspbot.net",
                 "country": "GB",
@@ -1092,6 +1100,7 @@
                 "source": "gds",
                 "protocol": "trisa",
                 "endpoint": "api.bob.vaspbot.net:443",
+                "travel_address": "ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr",
                 "name": "BobVASP",
                 "website": "https://bob.vaspbot.net",
                 "country": "US",
@@ -1110,6 +1119,7 @@
               "source": "gds",
               "protocol": "trisa",
               "endpoint": "api.alice.vaspbot.net:443",
+              "travel_address": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv",
               "name": "AliceCoin",
               "website": "https://alice.vaspbot.net",
               "country": "GB",
@@ -1120,6 +1130,7 @@
               "source": "gds",
               "protocol": "trisa",
               "endpoint": "api.bob.vaspbot.net:443",
+              "travel_address": "ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr",
               "name": "BobVASP",
               "website": "https://bob.vaspbot.net",
               "country": "US",
@@ -6484,6 +6495,7 @@
                       "source": "gds",
                       "protocol": "trisa",
                       "endpoint": "api.alice.vaspbot.net:443",
+                      "travel_address": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv",
                       "name": "AliceCoin",
                       "website": "https://alice.vaspbot.net",
                       "country": "GB",
@@ -6494,6 +6506,7 @@
                       "source": "gds",
                       "protocol": "trisa",
                       "endpoint": "api.bob.vaspbot.net:443",
+                      "travel_address": "ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr",
                       "name": "BobVASP",
                       "website": "https://bob.vaspbot.net",
                       "country": "US",
@@ -6700,6 +6713,7 @@
                       "source": "gds",
                       "protocol": "trisa",
                       "endpoint": "api.alice.vaspbot.net:443",
+                      "travel_address": "taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv",
                       "name": "AliceCoin",
                       "website": "https://alice.vaspbot.net",
                       "country": "GB",
@@ -6710,6 +6724,7 @@
                       "source": "gds",
                       "protocol": "trisa",
                       "endpoint": "api.bob.vaspbot.net:443",
+                      "travel_address": "ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr",
                       "name": "BobVASP",
                       "website": "https://bob.vaspbot.net",
                       "country": "US",

--- a/pkg/web/templates/openapi/openapi.yaml
+++ b/pkg/web/templates/openapi/openapi.yaml
@@ -606,7 +606,7 @@ components:
           enum:
             - trisa
             - trp
-            - email
+            - sunrise
           description: the travel rule protocol used to connect to the counterparty with.
           example: trisa
         common_name:
@@ -626,7 +626,7 @@ components:
           format: TravelAddress
           description: The counterparty travel address that allows the user to identify
             which counterparty to use in a transfer.
-          example: taYgWCfsnPN8hsqUAZWm4TW7WrHU5qZT3GiBPpfSApGSqoPMH1D6kiNRzST5Gz
+          example: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
         name:
           type: string
           description: The name of the counterparty, usually the counterparty's legal or
@@ -718,7 +718,7 @@ components:
         protocol: trisa
         common_name: api.alice.vaspbot.net
         endpoint: api.alice.vaspbot.net:443
-        travel_address: taYgWCfsnPN8hsqUAZWm4TW7WrHU5qZT3GiBPpfSApGSqoPMH1D6kiNRzST5Gz
+        travel_address: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
         name: AliceCoin
         website: https://alice.vaspbot.net
         country: GB
@@ -875,7 +875,7 @@ components:
           enum:
             - trisa
             - trp
-            - email
+            - sunrise
           description: the travel rule protocol used to connect to the counterparty with,
             used to filter the returned list.
           example: trisa
@@ -884,6 +884,12 @@ components:
           format: url
           description: the URL endpoint to connect to using the travel rule protocol.
           example: api.alice.vaspbot.net:443
+        travel_address:
+          type: string
+          format: TravelAddress
+          description: the travel address to address the counterparty with using TRP/TRISA
+            (empty for sunrise protocol)
+          example: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
         name:
           type: string
           description: The name of the counterparty, usually the counterparty's legal or
@@ -913,6 +919,7 @@ components:
         source: gds
         protocol: trisa
         endpoint: api.alice.vaspbot.net:443
+        travel_address: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
         name: AliceCoin
         website: https://alice.vaspbot.net
         country: GB
@@ -933,6 +940,7 @@ components:
               source: gds
               protocol: trisa
               endpoint: api.alice.vaspbot.net:443
+              travel_address: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
               name: AliceCoin
               website: https://alice.vaspbot.net
               country: GB
@@ -941,6 +949,7 @@ components:
               source: gds
               protocol: trisa
               endpoint: api.bob.vaspbot.net:443
+              travel_address: ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr
               name: BobVASP
               website: https://bob.vaspbot.net
               country: US
@@ -953,6 +962,7 @@ components:
             source: gds
             protocol: trisa
             endpoint: api.alice.vaspbot.net:443
+            travel_address: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
             name: AliceCoin
             website: https://alice.vaspbot.net
             country: GB
@@ -961,6 +971,7 @@ components:
             source: gds
             protocol: trisa
             endpoint: api.bob.vaspbot.net:443
+            travel_address: ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr
             name: BobVASP
             website: https://bob.vaspbot.net
             country: US
@@ -5176,6 +5187,7 @@ paths:
                     source: gds
                     protocol: trisa
                     endpoint: api.alice.vaspbot.net:443
+                    travel_address: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
                     name: AliceCoin
                     website: https://alice.vaspbot.net
                     country: GB
@@ -5184,6 +5196,7 @@ paths:
                     source: gds
                     protocol: trisa
                     endpoint: api.bob.vaspbot.net:443
+                    travel_address: ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr
                     name: BobVASP
                     website: https://bob.vaspbot.net
                     country: US
@@ -5317,6 +5330,7 @@ paths:
                     source: gds
                     protocol: trisa
                     endpoint: api.alice.vaspbot.net:443
+                    travel_address: taVwqXdsZdDVuWE2gbQgtdYECG6sGy9E1r3213WKPGyYfDv
                     name: AliceCoin
                     website: https://alice.vaspbot.net
                     country: GB
@@ -5325,6 +5339,7 @@ paths:
                     source: gds
                     protocol: trisa
                     endpoint: api.bob.vaspbot.net:443
+                    travel_address: ta2VBBr9q3A5rJ17Fx6b8NW82byUzGyeUMUWmNDUfmKtr
                     name: BobVASP
                     website: https://bob.vaspbot.net
                     country: US


### PR DESCRIPTION
### Scope of changes

Documents the fact that the Travel Address is returned in the List Counterparties and Search Counterparties endpoints.

Removes the VerifiedOn and Modified timestamp from the response if they are not available (zero valued or not queried).

### Type of change

- [ ] bug fix
- [ ] new feature
- [x] documentation
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation