### PR TITLE
[Docs] "sunrise" is the proper enum string for an email-based counterparty

### DIFF
--- a/pkg/web/templates/docs/openapi/openapi.json
+++ b/pkg/web/templates/docs/openapi/openapi.json
@@ -953,7 +953,7 @@
             "enum": [
               "trisa",
               "trp",
-              "email"
+              "sunrise"
             ],
             "description": "Specify the travel rule protocol used to connect to the counterparty with; this will likely be TRP or email since TRISA counterparties are fetched from the GDS.",
             "example": "trp"


### PR DESCRIPTION
### Scope of changes

OpenAPI docs fix: `"sunrise"` is the proper enum string when creating an email-based Counterparty.

### Type of change

- [x] bug fix
- [ ] new feature
- [x] documentation
- [ ] other (describe)

### Acceptance criteria

Nothing special required.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


