### PR TITLE
Webhook Compression

### DIFF
--- a/pkg/trisa/transfer.go
+++ b/pkg/trisa/transfer.go
@@ -389,6 +389,15 @@ func (s *Server) WebhookResponse(ctx context.Context, payload *api.Payload, p *p
 		return status.Error(codes.Unavailable, "envoy compliance callback is not available")
 	}
 
+	// If a 204 no content response is received, then return the default response.
+	if reply.TransferAction == webhook.DefaultTransferAction {
+		p.Log.Debug().Msg("received 204 no content from webhook callback, using default response")
+		if err = s.DefaultResponse(payload, p); err != nil {
+			return err
+		}
+	}
+
+	// Otherwise handle the payload received from the webhook callback.
 	// Sanity check the transaction id
 	if reply.TransactionID != request.TransactionID {
 		p.Log.Error().Msg("reply/request transaction id mismatch")

--- a/pkg/webhook/api.go
+++ b/pkg/webhook/api.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -55,6 +56,10 @@ type Reply struct {
 }
 
 const (
+	DefaultTransferAction = "default"
+)
+
+const (
 	transactionPBType = "type.googleapis.com/trisa.data.generic.v1beta1.Transaction"
 	pendingPBType     = "type.googleapis.com/trisa.data.generic.v1beta1.Pending"
 	sunrisePBType     = "type.googleapis.com/trisa.data.generic.v1beta1.Sunrise"
@@ -106,6 +111,11 @@ func (r *Request) AddPayload(payload *trisa.Payload) (err error) {
 // Determine the API transfer state based on the reply
 func (r *Reply) TransferState() trisa.TransferState {
 	// If the callback specifies "accepted" or "completed" then send that state on.
+	r.TransferAction = strings.ToLower(strings.TrimSpace(r.TransferAction))
+	if r.TransferAction == DefaultTransferAction {
+		return trisa.TransferStateUnspecified
+	}
+
 	if r.TransferAction != "" {
 		if state, _ := trisa.ParseTransferState(r.TransferAction); state != trisa.TransferStateUnspecified {
 			return state

--- a/pkg/webhook/api.go
+++ b/pkg/webhook/api.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -110,12 +109,12 @@ func (r *Request) AddPayload(payload *trisa.Payload) (err error) {
 
 // Determine the API transfer state based on the reply
 func (r *Reply) TransferState() trisa.TransferState {
-	// If the callback specifies "accepted" or "completed" then send that state on.
-	r.TransferAction = strings.ToLower(strings.TrimSpace(r.TransferAction))
+	// Ignore the default transfer action.
 	if r.TransferAction == DefaultTransferAction {
 		return trisa.TransferStateUnspecified
 	}
 
+	// If the callback specifies "accepted" or "completed" then send that state on.
 	if r.TransferAction != "" {
 		if state, _ := trisa.ParseTransferState(r.TransferAction); state != trisa.TransferStateUnspecified {
 			return state


### PR DESCRIPTION
### Scope of changes

Updates the webhook to handle compression from the content encoding header.

Also adds a "default" transfer action when a 204 response is returned to allow TRISA to just do what it would normally do in the case where the user wants to log the incoming request but is going to take no action.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review and tested in production! 😨 

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation