### PR TITLE
Webhook Authentication

### DIFF
--- a/cmd/envoy/main.go
+++ b/cmd/envoy/main.go
@@ -91,27 +91,6 @@ func main() {
 			},
 		},
 		{
-			Name:     "regentraveladdresses",
-			Usage:    "regenerate travel addresses for accounts and crypto addresses",
-			Category: "admin",
-			Before:   openDB,
-			Action:   regenerateTravelAddresses,
-			After:    closeDB,
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:    "endpoint",
-					Aliases: []string{"e"},
-					Usage:   "specify an endpoint to generate the addresses with",
-				},
-				&cli.StringFlag{
-					Name:    "protocol",
-					Aliases: []string{"p"},
-					Usage:   "specify the default protocol for the travel addresses",
-					Value:   "trisa",
-				},
-			},
-		},
-		{
 			Name:     "createuser",
 			Usage:    "create a new user to access Envoy with",
 			Category: "admin",
@@ -380,72 +359,6 @@ func remigrate(c *cli.Context) (err error) {
 // Administrative Commands
 //===========================================================================
 
-func regenerateTravelAddresses(c *cli.Context) (err error) {
-	var endpoint string
-	if endpoint = c.String("endpoint"); endpoint == "" {
-		endpoint = conf.Node.Endpoint
-	}
-
-	var factory models.TravelAddressFactory
-	if factory, err = models.NewTravelAddressFactory(endpoint, c.String("protocol")); err != nil {
-		return cli.Exit(err, 1)
-	}
-
-	updateAccount := func(account *models.Account) (err error) {
-		if account.TravelAddress.String, err = factory(account); err != nil {
-			return fmt.Errorf("could not update travel address for account %s: %w", account.ID, err)
-		}
-		account.TravelAddress.Valid = account.TravelAddress.String != ""
-
-		if err = db.UpdateAccount(context.Background(), account); err != nil {
-			return fmt.Errorf("could not update account %s: %w", account.ID, err)
-		}
-
-		return nil
-	}
-
-	updateCryptoAddress := func(addr *models.CryptoAddress) (err error) {
-		if addr.TravelAddress.String, err = factory(addr); err != nil {
-			return fmt.Errorf("could not update travel address for crypto address %s: %w", addr.ID, err)
-		}
-
-		addr.TravelAddress.Valid = addr.TravelAddress.String != ""
-
-		if err = db.UpdateCryptoAddress(context.Background(), addr); err != nil {
-			return fmt.Errorf("could not update crypto address %s: %w", addr.ID, err)
-		}
-
-		return nil
-	}
-
-	// Go through all accounts and update their travel addresses
-	// TODO: handle pagination
-	var accounts *models.AccountsPage
-	if accounts, err = db.ListAccounts(context.Background(), nil); err != nil {
-		return cli.Exit(err, 1)
-	}
-
-	for _, account := range accounts.Accounts {
-		if err = updateAccount(account); err != nil {
-			fmt.Println(err)
-		}
-
-		var addrs *models.CryptoAddressPage
-		if addrs, err = db.ListCryptoAddresses(context.Background(), account.ID, nil); err != nil {
-			return cli.Exit(err, 1)
-		}
-
-		// TODO: handle pagination
-		for _, addr := range addrs.CryptoAddresses {
-			if err = updateCryptoAddress(addr); err != nil {
-				fmt.Println(err)
-			}
-		}
-	}
-
-	return nil
-}
-
 var roles = map[string]int64{
 	"admin":      1,
 	"compliance": 2,
@@ -578,13 +491,13 @@ func generateHMACKey(c *cli.Context) (err error) {
 		return cli.Exit(err, 1)
 	}
 
-	keyid := ulid.Make()
+	keyID := ulid.Make()
 	keys := hex.EncodeToString(key)
 
 	if out := c.String("out"); out != "" {
 		data := map[string]string{
 			"key":   keys,
-			"keyID": keys,
+			"keyID": keyID.String(),
 		}
 
 		var f *os.File
@@ -598,7 +511,7 @@ func generateHMACKey(c *cli.Context) (err error) {
 		}
 
 	} else {
-		fmt.Printf("Key ID: %s\nKey: %s\n", keyid, keys)
+		fmt.Printf("Key ID: %s\nKey: %s\n", keyID, keys)
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,9 +31,9 @@ type Config struct {
 	LogLevel        logger.LevelDecoder `split_words:"true" default:"info" desc:"specify the verbosity of logging (trace, debug, info, warn, error, fatal panic)"`
 	ConsoleLog      bool                `split_words:"true" default:"false" desc:"if true logs colorized human readable output instead of json"`
 	DatabaseURL     string              `split_words:"true" default:"sqlite3:///trisa.db" desc:"dsn containing backend database configuration"`
-	WebhookURL      string              `split_words:"true" desc:"specify a callback webhook that incoming travel rule messages will be posted to"`
 	SearchThreshold float64             `split_words:"true" default:"0.0" desc:"specify the threshold for fuzzy search (0.0 to 1.0)"`
 	Web             WebConfig           `split_words:"true"`
+	Webhook         WebhookConfig       `split_words:"true"`
 	Node            TRISAConfig         `split_words:"true"`
 	DirectorySync   DirectorySyncConfig `split_words:"true"`
 	TRP             TRPConfig           `split_words:"true"`
@@ -119,6 +119,10 @@ type SunriseConfig struct {
 	inviteURL      *url.URL
 }
 
+type WebhookConfig struct {
+	URL string `required:"false" desc:"specify a callback webhook that incoming travel rule messages will be posted to"`
+}
+
 // Optional region and deployment information associated with the node.
 type RegionInfo struct {
 	ID      int32  `env:"REGION_INFO_ID" desc:"the 7 digit region identifier code"`
@@ -154,13 +158,11 @@ func (c Config) Validate() (err error) {
 		return fmt.Errorf("invalid configuration: %q is not a valid gin mode", c.Mode)
 	}
 
-	if c.WebhookURL != "" {
-		if _, err = url.Parse(c.WebhookURL); err != nil {
-			return fmt.Errorf("invalid configuration: could not parse webhook url: %w", err)
-		}
+	if err = c.Web.Validate(); err != nil {
+		return err
 	}
 
-	if err = c.Web.Validate(); err != nil {
+	if err = c.Webhook.Validate(); err != nil {
 		return err
 	}
 
@@ -169,19 +171,6 @@ func (c Config) Validate() (err error) {
 
 func (c Config) GetLogLevel() zerolog.Level {
 	return zerolog.Level(c.LogLevel)
-}
-
-func (c Config) WebhookEnabled() bool {
-	return c.WebhookURL != ""
-}
-
-func (c Config) Webhook() *url.URL {
-	if c.WebhookURL == "" {
-		return nil
-	}
-
-	u, _ := url.Parse(c.WebhookURL)
-	return u
 }
 
 func (c WebConfig) Validate() (err error) {
@@ -204,6 +193,28 @@ func (c WebConfig) Validate() (err error) {
 	}
 
 	return nil
+}
+
+func (c WebhookConfig) Validate() (err error) {
+	if c.Enabled() {
+		if _, err = url.Parse(c.URL); err != nil {
+			return fmt.Errorf("invalid configuration: could not parse webhook url: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c WebhookConfig) Enabled() bool {
+	return c.URL != ""
+}
+
+func (c WebhookConfig) Endpoint() *url.URL {
+	if c.URL == "" {
+		return nil
+	}
+
+	u, _ := url.Parse(c.URL)
+	return u
 }
 
 // Validate that the TRISA config has mTLS certificates for operation.

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -82,8 +82,8 @@ func New(conf config.Config) (node *Node, err error) {
 	}
 
 	// Configure the webhook if it's enabled
-	if conf.WebhookEnabled() {
-		node.webhook = webhook.New(conf.Webhook())
+	if conf.Webhook.Enabled() {
+		node.webhook = webhook.New(conf.Webhook.Endpoint())
 	}
 
 	// Configure email if it's available

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -83,7 +83,7 @@ func New(conf config.Config) (node *Node, err error) {
 
 	// Configure the webhook if it's enabled
 	if conf.Webhook.Enabled() {
-		node.webhook = webhook.New(conf.Webhook.Endpoint())
+		node.webhook = webhook.New(conf.Webhook)
 	}
 
 	// Configure email if it's available

--- a/pkg/webhook/auth.go
+++ b/pkg/webhook/auth.go
@@ -171,6 +171,10 @@ func (h *HMACToken) KeyID() string {
 	return h.keyID
 }
 
+func (h *HMACToken) Headers() []string {
+	return h.headers
+}
+
 func (h *HMACToken) Collect(headers http.Header) {
 	for _, header := range h.headers {
 		if value := headers.Get(header); value != "" {

--- a/pkg/webhook/auth.go
+++ b/pkg/webhook/auth.go
@@ -5,9 +5,15 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
+)
+
+var (
+	ErrInvalidHMACToken = errors.New("invalid authorization hmac token")
 )
 
 // HMAC implements an authorization header to authenticate webhook requests using a
@@ -44,7 +50,7 @@ func NewHMAC(keyID string, key []byte) *HMAC {
 // the headers are added is important as the values will be appended without
 // modification to the data to be signed. If the header is already present, it will
 // not be added again. Headers are stored as lowercase values.
-func (h *HMAC) AddHeader(header, value string) {
+func (h *HMAC) Append(header, value string) {
 	header = strings.ToLower(header)
 	if slices.Contains(h.headers, header) {
 		return
@@ -56,7 +62,7 @@ func (h *HMAC) AddHeader(header, value string) {
 
 // Nonce returns the base64 encoded nonce that is used to prevent replay attacks.
 func (h *HMAC) Nonce() string {
-	return base64.URLEncoding.EncodeToString(h.data[:16])
+	return base64.RawURLEncoding.EncodeToString(h.data[:16])
 }
 
 // Signature returns the base64 encoded HMAC-SHA256 signature of the data.
@@ -65,7 +71,7 @@ func (h *HMAC) Signature() (_ string, err error) {
 	if _, err = mac.Write(h.data); err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(mac.Sum(nil)), nil
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 }
 
 // Headers returns the semicolon list of request headers used to compute the signature.
@@ -90,4 +96,98 @@ func (h *HMAC) Authorization() (_ string, err error) {
 	}
 
 	return fmt.Sprintf("HMAC sig=%s, nonce=%s, headers=%s, kid=%s", sig, h.Nonce(), h.Headers(), h.Key()), nil
+}
+
+// HMACToken is parsed from an Authorization or Server-Authorization header and is
+// used to verify the signature of a webhook request.
+type HMACToken struct {
+	headers   []string
+	data      []byte
+	keyID     string
+	signature []byte
+}
+
+func ParseHMAC(token string) (tok *HMACToken, err error) {
+	if !strings.HasPrefix(token, "HMAC ") {
+		return nil, ErrInvalidHMACToken
+	}
+
+	token = strings.TrimPrefix(token, "HMAC ")
+	parts := strings.Split(token, ",")
+	kv := make(map[string]string, len(parts))
+
+	for _, part := range parts {
+		kvp := strings.SplitN(part, "=", 2)
+		kv[strings.TrimSpace(kvp[0])] = strings.TrimSpace(kvp[1])
+	}
+
+	tok = &HMACToken{}
+
+	if sig, ok := kv["sig"]; ok {
+		if tok.signature, err = base64.RawURLEncoding.DecodeString(sig); err != nil {
+			return nil, fmt.Errorf("could not decode signature: %w", err)
+		}
+	} else {
+		return nil, fmt.Errorf("missing signature in HMAC token")
+	}
+
+	if nonce, ok := kv["nonce"]; ok {
+		if tok.data, err = base64.RawURLEncoding.DecodeString(nonce); err != nil {
+			return nil, fmt.Errorf("could not decode nonce: %w", err)
+		}
+	} else {
+		return nil, fmt.Errorf("missing nonce in HMAC token")
+	}
+
+	if headers, ok := kv["headers"]; ok {
+		tok.headers = strings.Split(headers, ";")
+		for i := range tok.headers {
+			tok.headers[i] = strings.TrimSpace(tok.headers[i])
+			if tok.headers[i] == "" {
+				tok.headers = append(tok.headers[:i], tok.headers[i+1:]...)
+			}
+		}
+
+		if len(tok.headers) == 0 {
+			return nil, fmt.Errorf("could not decode headers in HMAC token")
+		}
+	} else {
+		return nil, fmt.Errorf("missing headers in HMAC token")
+	}
+
+	if kid, ok := kv["kid"]; ok {
+		tok.keyID = kid
+		if tok.keyID == "" {
+			return nil, fmt.Errorf("could not decode key ID in HMAC token")
+		}
+	} else {
+		return nil, fmt.Errorf("missing key ID in HMAC token")
+	}
+
+	return tok, nil
+}
+
+func (h *HMACToken) KeyID() string {
+	return h.keyID
+}
+
+func (h *HMACToken) Collect(headers http.Header) {
+	for _, header := range h.headers {
+		if value := headers.Get(header); value != "" {
+			h.data = append(h.data, []byte(value)...)
+		}
+	}
+}
+
+func (h *HMACToken) Verify(key []byte) (bool, error) {
+	mac := hmac.New(sha256.New, key)
+	if _, err := mac.Write(h.data); err != nil {
+		return false, err
+	}
+
+	if !hmac.Equal(mac.Sum(nil), h.signature) {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/webhook/auth.go
+++ b/pkg/webhook/auth.go
@@ -1,0 +1,93 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// HMAC implements an authorization header to authenticate webhook requests using a
+// similar shared secret mechanism as AWS4-HMAC-SHA256 as defined here:
+// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+//
+// Create an HMAC object with a 32 byte key and a string that represents the key ID.
+// Headers then must be appended to the HMAC in order to generate the data to sign.
+// Once signed, an HMAC-SHA256 signature is generated and can be used to create the
+// Authorization header.
+type HMAC struct {
+	headers []string
+	data    []byte
+	key     []byte
+	keyID   string
+}
+
+func NewHMAC(keyID string, key []byte) *HMAC {
+	// Create a nonce to prevent replay attacks as a prefix to the signed data.
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		panic(fmt.Errorf("could not create nonce for HMAC: %w", err))
+	}
+
+	return &HMAC{
+		headers: make([]string, 0),
+		data:    nonce,
+		key:     key,
+		keyID:   keyID,
+	}
+}
+
+// Add the header and the header value to the HMAC object. Note that the order that
+// the headers are added is important as the values will be appended without
+// modification to the data to be signed. If the header is already present, it will
+// not be added again. Headers are stored as lowercase values.
+func (h *HMAC) AddHeader(header, value string) {
+	header = strings.ToLower(header)
+	if slices.Contains(h.headers, header) {
+		return
+	}
+
+	h.headers = append(h.headers, header)
+	h.data = append(h.data, []byte(value)...)
+}
+
+// Nonce returns the base64 encoded nonce that is used to prevent replay attacks.
+func (h *HMAC) Nonce() string {
+	return base64.URLEncoding.EncodeToString(h.data[:16])
+}
+
+// Signature returns the base64 encoded HMAC-SHA256 signature of the data.
+func (h *HMAC) Signature() (_ string, err error) {
+	mac := hmac.New(sha256.New, h.key)
+	if _, err = mac.Write(h.data); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+// Headers returns the semicolon list of request headers used to compute the signature.
+// The list includes header names only, and the header names must be in lowercase.
+// The order of the headers indicates the order the data was appended to create the
+// signature.
+func (h *HMAC) Headers() string {
+	return strings.Join(h.headers, ";")
+}
+
+// Key returns the key ID used to create the HMAC signature.
+func (h *HMAC) Key() string {
+	return h.keyID
+}
+
+// Authorization returns the full Authorization header that can be added to the
+// request headers of an outgoing webhook request.
+func (h *HMAC) Authorization() (_ string, err error) {
+	var sig string
+	if sig, err = h.Signature(); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("HMAC sig=%s, nonce=%s, headers=%s, kid=%s", sig, h.Nonce(), h.Headers(), h.Key()), nil
+}

--- a/pkg/webhook/auth_test.go
+++ b/pkg/webhook/auth_test.go
@@ -2,6 +2,8 @@ package webhook_test
 
 import (
 	"encoding/hex"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,11 +14,121 @@ func TestHMAC(t *testing.T) {
 	key, _ := hex.DecodeString("cfbabc4715b4759d45ba26953dd2fc0bfc2344ef70a2005432e7f16b5081610d")
 	keyID := "01JT4B3R5Z6AHJXV87QHPPKRBM"
 
+	headers := make(http.Header)
+	headers.Set("Host", "example.com")
+	headers.Set("X-Transaction-ID", "f17c9693-c280-4836-b544-245d832a11e0")
+
 	mac := webhook.NewHMAC(keyID, key)
-	mac.AddHeader("Host", "example.com")
-	mac.AddHeader("X-Transaction-ID", "f17c9693-c280-4836-b544-245d832a11e0")
+	for header := range headers {
+		mac.Append(header, headers.Get(header))
+	}
+
+	sig, err := mac.Signature()
+	require.NoError(t, err, "could not create signature")
+
+	require.Regexp(t, `^[A-Za-z0-9\-_]{22}$`, mac.Nonce(), "nonce is not 16 base64 encoded bytes")
+	require.Regexp(t, `^[A-Za-z0-9\-_]{43}$`, sig, "signature is not 32 base64 encoded bytes")
+	require.Equal(t, "host;x-transaction-id", mac.Headers(), "headers do not match")
+	require.Equal(t, keyID, mac.Key(), "key ID does not match")
 
 	auth, err := mac.Authorization()
 	require.NoError(t, err, "could not create authorization header")
-	require.NotEmpty(t, auth, "authorization header is empty")
+	require.True(t, strings.HasPrefix(auth, "HMAC "))
+
+	token, err := webhook.ParseHMAC(auth)
+	require.NoError(t, err, "could not parse authorization header")
+	require.Equal(t, mac.Key(), token.KeyID(), "key ID does not match")
+
+	token.Collect(headers)
+	ok, err := token.Verify(key)
+	require.NoError(t, err, "could not verify token")
+	require.True(t, ok, "token verification failed")
+}
+
+func TestInvalidHMAC(t *testing.T) {
+	key, _ := hex.DecodeString("cfbabc4715b4759d45ba26953dd2fc0bfc2344ef70a2005432e7f16b5081610d")
+	keyID := "01JT4B3R5Z6AHJXV87QHPPKRBM"
+
+	headers := make(http.Header)
+	headers.Set("Host", "example.com")
+	headers.Set("X-Transaction-ID", "f17c9693-c280-4836-b544-245d832a11e0")
+
+	mac := webhook.NewHMAC(keyID, key)
+	for header := range headers {
+		mac.Append(header, headers.Get(header))
+	}
+
+	auth, err := mac.Authorization()
+	require.NoError(t, err, "could not create authorization header")
+
+	token, err := webhook.ParseHMAC(auth)
+	require.NoError(t, err, "could not parse authorization header")
+
+	token.Collect(headers)
+
+	ok, err := token.Verify([]byte("bad key"))
+	require.NoError(t, err, "could not verify token with bad key")
+	require.False(t, ok, "token verification should fail with bad key")
+}
+
+func TestBadTokens(t *testing.T) {
+	// Test invalid tokens
+	tokens := []struct {
+		token string
+		err   string
+	}{
+		{
+			"foo", "invalid authorization hmac token",
+		},
+		{
+			"", "invalid authorization hmac token",
+		},
+		{
+			"HMAC", "invalid authorization hmac token",
+		},
+		{
+			"HMAC sig=f+, nonce=wm0eHegl4lD0Uw_sSYYQCw, headers=host;x-transaction-id, kid=01JT4B3R5Z6AHJXV87QHPPKRBM",
+			"could not decode signature: illegal base64 data at input byte 1",
+		},
+		{
+			"HMAC nonce=wm0eHegl4lD0Uw_sSYYQCw, headers=host;x-transaction-id, kid=01JT4B3R5Z6AHJXV87QHPPKRBM",
+			"missing signature in HMAC token",
+		},
+		{
+			"HMAC sig=zFeIxdyVnJtpMUExK7HoL37VN4tF6sMQZPEr58MBpMQ, nonce=f+, headers=host;x-transaction-id, kid=01JT4B3R5Z6AHJXV87QHPPKRBM",
+			"could not decode nonce: illegal base64 data at input byte 1",
+		},
+		{
+			"HMAC sig=zFeIxdyVnJtpMUExK7HoL37VN4tF6sMQZPEr58MBpMQ, headers=host;x-transaction-id, kid=01JT4B3R5Z6AHJXV87QHPPKRBM",
+			"missing nonce in HMAC token",
+		},
+		{
+			"HMAC sig=zFeIxdyVnJtpMUExK7HoL37VN4tF6sMQZPEr58MBpMQ, nonce=wm0eHegl4lD0Uw_sSYYQCw, headers=, kid=01JT4B3R5Z6AHJXV87QHPPKRBM",
+			"could not decode headers in HMAC token",
+		},
+		{
+			"HMAC sig=zFeIxdyVnJtpMUExK7HoL37VN4tF6sMQZPEr58MBpMQ, nonce=wm0eHegl4lD0Uw_sSYYQCw, kid=01JT4B3R5Z6AHJXV87QHPPKRBM",
+			"missing headers in HMAC token",
+		},
+		{
+			"HMAC sig=zFeIxdyVnJtpMUExK7HoL37VN4tF6sMQZPEr58MBpMQ, nonce=wm0eHegl4lD0Uw_sSYYQCw, headers=host;x-transaction-id, kid=",
+			"could not decode key ID in HMAC token",
+		},
+		{
+			"HMAC sig=zFeIxdyVnJtpMUExK7HoL37VN4tF6sMQZPEr58MBpMQ, nonce=wm0eHegl4lD0Uw_sSYYQCw, headers=host;x-transaction-id",
+			"missing key ID in HMAC token",
+		},
+	}
+
+	for i, tc := range tokens {
+		tok, err := webhook.ParseHMAC(tc.token)
+		require.EqualError(t, err, tc.err, "test case %d: expected error %q, got %q", i, tc.err, err)
+		require.Nil(t, tok, "test case %d: expected nil token, got %v", i, tok)
+	}
+}
+
+func TestExtraKeys(t *testing.T) {
+	token := "HMAC foo=bar, sig=zFeIxdyVnJtpMUExK7HoL37VN4tF6sMQZPEr58MBpMQ, nonce=wm0eHegl4lD0Uw_sSYYQCw, headers=host;x-transaction-id, kid=01JT4B3R5Z6AHJXV87QHPPKRBM,color=red"
+	_, err := webhook.ParseHMAC(token)
+	require.NoError(t, err, "could not parse token with extra keys")
 }

--- a/pkg/webhook/auth_test.go
+++ b/pkg/webhook/auth_test.go
@@ -1,0 +1,22 @@
+package webhook_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/envoy/pkg/webhook"
+)
+
+func TestHMAC(t *testing.T) {
+	key, _ := hex.DecodeString("cfbabc4715b4759d45ba26953dd2fc0bfc2344ef70a2005432e7f16b5081610d")
+	keyID := "01JT4B3R5Z6AHJXV87QHPPKRBM"
+
+	mac := webhook.NewHMAC(keyID, key)
+	mac.AddHeader("Host", "example.com")
+	mac.AddHeader("X-Transaction-ID", "f17c9693-c280-4836-b544-245d832a11e0")
+
+	auth, err := mac.Authorization()
+	require.NoError(t, err, "could not create authorization header")
+	require.NotEmpty(t, auth, "authorization header is empty")
+}

--- a/pkg/webhook/auth_test.go
+++ b/pkg/webhook/auth_test.go
@@ -19,9 +19,8 @@ func TestHMAC(t *testing.T) {
 	headers.Set("X-Transaction-ID", "f17c9693-c280-4836-b544-245d832a11e0")
 
 	mac := webhook.NewHMAC(keyID, key)
-	for header := range headers {
-		mac.Append(header, headers.Get(header))
-	}
+	mac.Append("Host", headers.Get("Host"))
+	mac.Append("X-Transaction-ID", headers.Get("X-Transaction-ID"))
 
 	sig, err := mac.Signature()
 	require.NoError(t, err, "could not create signature")

--- a/pkg/webhook/mock.go
+++ b/pkg/webhook/mock.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/url"
 	"os"
 	"time"
 
+	"github.com/trisacrypto/envoy/pkg/config"
 	trisa "github.com/trisacrypto/trisa/pkg/trisa/api/v1beta1"
 	generic "github.com/trisacrypto/trisa/pkg/trisa/data/generic/v1beta1"
 )
@@ -17,16 +17,18 @@ const (
 	mockScheme = "mock"
 )
 
-var MockURL *url.URL
-
-func init() {
-	MockURL, _ = url.Parse(mockURL)
+var MockConfig = config.WebhookConfig{
+	URL: mockURL,
 }
 
 // Mock implements the webhook Handler and is used for testing webhook interactions.
 type Mock struct {
 	OnCallback func(context.Context, *Request) (*Reply, error)
 	Callbacks  int
+}
+
+func NewMock() *Mock {
+	return &Mock{}
 }
 
 func (m *Mock) Callback(ctx context.Context, req *Request) (*Reply, error) {

--- a/pkg/webhook/mock_test.go
+++ b/pkg/webhook/mock_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestMockURL(t *testing.T) {
-	require.Equal(t, "mock", webhook.MockURL.Scheme)
+	require.Equal(t, "mock", webhook.MockConfig.Endpoint().Scheme)
 }
 
 func TestMock(t *testing.T) {
-	cb := webhook.New(webhook.MockURL)
+	cb := webhook.New(webhook.MockConfig)
 	require.IsType(t, &webhook.Mock{}, cb, "expected mock handler to be returned")
 
 	req, err := loadRequest("transaction_payload.json")
@@ -39,7 +39,7 @@ func TestMock(t *testing.T) {
 }
 
 func TestMockReply(t *testing.T) {
-	cb := webhook.New(webhook.MockURL)
+	cb := webhook.New(webhook.MockConfig)
 	require.IsType(t, &webhook.Mock{}, cb, "expected mock handler to be returned")
 
 	mock := cb.(*webhook.Mock)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -3,6 +3,7 @@ package webhook_test
 import (
 	"compress/gzip"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/envoy/pkg/config"
 	"github.com/trisacrypto/envoy/pkg/webhook"
 	trisa "github.com/trisacrypto/trisa/pkg/trisa/api/v1beta1"
 )
@@ -32,7 +34,7 @@ func TestWebhook(t *testing.T) {
 		endpoint, _ := url.Parse(srv.URL)
 		endpoint.Path = "/"
 
-		cb := webhook.New(endpoint)
+		cb := webhook.New(config.WebhookConfig{URL: endpoint.String()})
 		require.IsType(t, &webhook.Webhook{}, cb, "unexpected webhook handler for real url")
 
 		rep, err := cb.Callback(ctx, req)
@@ -51,7 +53,7 @@ func TestWebhook(t *testing.T) {
 		endpoint, _ := url.Parse(srv.URL)
 		endpoint.Path = "/"
 
-		cb := webhook.New(endpoint)
+		cb := webhook.New(config.WebhookConfig{URL: endpoint.String()})
 		require.IsType(t, &webhook.Webhook{}, cb, "unexpected webhook handler for real url")
 
 		rep, err := cb.Callback(ctx, req)
@@ -70,7 +72,7 @@ func TestWebhook(t *testing.T) {
 		endpoint, _ := url.Parse(srv.URL)
 		endpoint.Path = "/"
 
-		cb := webhook.New(endpoint)
+		cb := webhook.New(config.WebhookConfig{URL: endpoint.String()})
 		require.IsType(t, &webhook.Webhook{}, cb, "unexpected webhook handler for real url")
 
 		rep, err := cb.Callback(ctx, req)
@@ -89,7 +91,7 @@ func TestWebhook(t *testing.T) {
 		endpoint, _ := url.Parse(srv.URL)
 		endpoint.Path = "/"
 
-		cb := webhook.New(endpoint)
+		cb := webhook.New(config.WebhookConfig{URL: endpoint.String()})
 		require.IsType(t, &webhook.Webhook{}, cb, "unexpected webhook handler for real url")
 
 		rep, err := cb.Callback(ctx, req)
@@ -104,7 +106,7 @@ func TestWebhook(t *testing.T) {
 		endpoint, _ := url.Parse(srv.URL)
 		endpoint.Path = "/"
 
-		cb := webhook.New(endpoint)
+		cb := webhook.New(config.WebhookConfig{URL: endpoint.String()})
 		require.IsType(t, &webhook.Webhook{}, cb, "unexpected webhook handler for real url")
 
 		rep, err := cb.Callback(ctx, req)
@@ -114,6 +116,65 @@ func TestWebhook(t *testing.T) {
 
 		require.Nil(t, rep.Error, "expected a nil error returned")
 		require.Nil(t, rep.Payload, "expoected a nil payload returned")
+	})
+
+	t.Run("ClientAuth", func(t *testing.T) {
+		srv := httptest.NewServer(makeWebhookAuthHandler())
+		defer srv.Close()
+
+		endpoint, _ := url.Parse(srv.URL)
+		endpoint.Path = "/"
+
+		cb := webhook.New(config.WebhookConfig{
+			URL:               endpoint.String(),
+			AuthKeyID:         "01JT4B3R5Z6AHJXV87QHPPKRBM",
+			AuthKeySecret:     "cfbabc4715b4759d45ba26953dd2fc0bfc2344ef70a2005432e7f16b5081610d",
+			RequireServerAuth: false,
+		})
+
+		rep, err := cb.Callback(ctx, req)
+		require.NoError(t, err, "could not execute callback request")
+		require.NotNil(t, rep, "a reply was not returned by the callback")
+		require.Equal(t, rep.TransferAction, webhook.DefaultTransferAction, "expected the default transfer action")
+	})
+
+	t.Run("BadClientAuth", func(t *testing.T) {
+		srv := httptest.NewServer(makeWebhookAuthHandler())
+		defer srv.Close()
+
+		endpoint, _ := url.Parse(srv.URL)
+		endpoint.Path = "/"
+
+		cb := webhook.New(config.WebhookConfig{
+			URL:               endpoint.String(),
+			AuthKeyID:         "01JT4JY0MS4BDJAT4BA9T4621Y",
+			AuthKeySecret:     "9b33d18fe311b4a0155dde8ca61b94afbce14193232f2c69f5630c6e73818f22",
+			RequireServerAuth: false,
+		})
+
+		_, err := cb.Callback(ctx, req)
+		require.Error(t, err, "could not execute callback request")
+		require.EqualError(t, err, "could not make webhook callback: received status 401 Unauthorized")
+	})
+
+	t.Run("ServerAuth", func(t *testing.T) {
+		srv := httptest.NewServer(makeWebhookAuthHandler())
+		defer srv.Close()
+
+		endpoint, _ := url.Parse(srv.URL)
+		endpoint.Path = "/"
+
+		cb := webhook.New(config.WebhookConfig{
+			URL:               endpoint.String(),
+			AuthKeyID:         "01JT4B3R5Z6AHJXV87QHPPKRBM",
+			AuthKeySecret:     "cfbabc4715b4759d45ba26953dd2fc0bfc2344ef70a2005432e7f16b5081610d",
+			RequireServerAuth: true,
+		})
+
+		rep, err := cb.Callback(ctx, req)
+		require.NoError(t, err, "could not execute callback request")
+		require.NotNil(t, rep, "a reply was not returned by the callback")
+		require.Equal(t, rep.TransferAction, webhook.DefaultTransferAction, "expected the default transfer action")
 	})
 }
 
@@ -166,6 +227,49 @@ func makeWebhookError(msg string, code int) http.HandlerFunc {
 
 func makeWebhookNoContent() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func makeWebhookAuthHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			err   error
+			token *webhook.HMACToken
+			key   []byte
+		)
+
+		key, _ = hex.DecodeString("cfbabc4715b4759d45ba26953dd2fc0bfc2344ef70a2005432e7f16b5081610d")
+
+		// Require authentication header
+		if token, err = webhook.ParseHMAC(r.Header.Get("Authorization")); err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		token.Collect(r.Header)
+		if valid, err := token.Verify(key); err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		} else if !valid {
+			http.Error(w, "could not verify auth token", http.StatusUnauthorized)
+			return
+		}
+
+		// Echo a Server-Authorization header back to the client
+		mac := webhook.NewHMAC("01JT4B3R5Z6AHJXV87QHPPKRBM", key)
+		for _, header := range token.Headers() {
+			mac.Append(header, r.Header.Get(header))
+			w.Header().Set(header, r.Header.Get(header))
+		}
+
+		if auth, err := mac.Authorization(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		} else {
+			w.Header().Set("Server-Authorization", auth)
+		}
+
 		w.WriteHeader(http.StatusNoContent)
 	}
 }


### PR DESCRIPTION
### Scope of changes

This PR implements an authentication mechanism for webhook requests that uses a method similar to [Hawk](https://mohawk.readthedocs.io/en/latest/usage.html#sending-a-request) and [AWS HMAC-256](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html) authentication. 

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Does this authentication method make sense? Any reason to suspect this won't provide good security? Should we perform server validation as well?

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


