### PR TITLE
Allow CounterpartyID for all transactions using "prepare" and "send-prepared"

### DIFF
--- a/pkg/store/sqlite/sunrise.go
+++ b/pkg/store/sqlite/sunrise.go
@@ -286,7 +286,7 @@ func (s *Store) GetOrCreateSunriseCounterparty(ctx context.Context, email, name 
 }
 
 func lookupContactCounterparty(tx *sql.Tx, email string) (counterpartyID ulid.ULID, err error) {
-	if err = tx.QueryRow(lookupContactEmailSQL, sql.Named("email", email)).Scan(&counterpartyID); err != nil {
+	if err = tx.QueryRow(lookupContactEmailSQL, sql.Named("email", strings.ToLower(email))).Scan(&counterpartyID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ulid.ULID{}, dberr.ErrNotFound
 		}

--- a/pkg/store/sqlite/sunrise.go
+++ b/pkg/store/sqlite/sunrise.go
@@ -195,7 +195,7 @@ func (s *Store) DeleteSunrise(ctx context.Context, id ulid.ULID) (err error) {
 }
 
 const (
-	lookupContactEmailSQL     = "SELECT counterparty_id FROM contacts WHERE email=:email"
+	lookupContactEmailSQL     = "SELECT counterparty_id FROM contacts WHERE LOWER(email)=LOWER(:email)"
 	countCounterpartyNameSQL  = "SELECT count(id) FROM counterparties WHERE name LIKE :name"
 	lookupCounterpartyNameSQL = "SELECT id FROM counterparties WHERE name LIKE :name LIMIT 1"
 )
@@ -286,7 +286,7 @@ func (s *Store) GetOrCreateSunriseCounterparty(ctx context.Context, email, name 
 }
 
 func lookupContactCounterparty(tx *sql.Tx, email string) (counterpartyID ulid.ULID, err error) {
-	if err = tx.QueryRow(lookupContactEmailSQL, sql.Named("email", strings.ToLower(email))).Scan(&counterpartyID); err != nil {
+	if err = tx.QueryRow(lookupContactEmailSQL, sql.Named("email", email)).Scan(&counterpartyID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ulid.ULID{}, dberr.ErrNotFound
 		}

--- a/pkg/web/routing.go
+++ b/pkg/web/routing.go
@@ -78,15 +78,15 @@ func (s *Server) ResolveCounterparty(c *gin.Context, in *api.Routing) (vasp *mod
 	}
 
 	switch {
-		// If vasp is nil we probably shouldn't have made it this far in the code, but protecting ourselves anyway.
-		case vasp == nil:
-			c.JSON(http.StatusNotFound, api.Error("could not identify counterparty from routing information"))
-			return nil, errors.New("unhandled nil vasp at end of resolve counterparty")
-		case vasp.Protocol != protocol:
-			err := errors.New("could not find counterparty that supports requested protocol")
-			c.JSON(http.StatusNotFound, api.Error(err)
-			return nil, err
-		default:
+	// If vasp is nil we probably shouldn't have made it this far in the code, but protecting ourselves anyway.
+	case vasp == nil:
+		c.JSON(http.StatusNotFound, api.Error("could not identify counterparty from routing information"))
+		return nil, errors.New("unhandled nil vasp at end of resolve counterparty")
+	case vasp.Protocol != protocol:
+		err := errors.New("could not find counterparty that supports requested protocol")
+		c.JSON(http.StatusNotFound, api.Error(err))
+		return nil, err
+	default:
 		return vasp, nil
 	}
 }

--- a/pkg/web/routing.go
+++ b/pkg/web/routing.go
@@ -32,51 +32,58 @@ func (s *Server) ResolveCounterparty(c *gin.Context, in *api.Routing) (vasp *mod
 	}
 
 	ctx := c.Request.Context()
-	switch protocol {
-	case enum.ProtocolTRISA:
-		// Ideally we look up the counterparty by ID
-		if !in.CounterpartyID.IsZero() {
-			if vasp, err = s.store.RetrieveCounterparty(ctx, in.CounterpartyID); err != nil {
-				if errors.Is(err, dberr.ErrNotFound) {
-					c.JSON(http.StatusNotFound, api.Error("could not identify counterparty from routing information"))
-					return nil, err
-				}
 
-				c.Error(err)
-				c.JSON(http.StatusInternalServerError, api.Error("could not identify counterparty from routing information"))
+	// Ideally we look up the counterparty by ID for any protocol
+	if !in.CounterpartyID.IsZero() {
+		if vasp, err = s.store.RetrieveCounterparty(ctx, in.CounterpartyID); err != nil {
+			if errors.Is(err, dberr.ErrNotFound) {
+				c.JSON(http.StatusNotFound, api.Error("could not identify counterparty from routing information"))
 				return nil, err
 			}
-			return vasp, nil
-		}
 
-		// Alternatively, lookup the counterparty by travel address
-		if vasp, err = s.CounterpartyFromTravelAddress(c, in.TravelAddress); err != nil {
-			// NOTE: CounterpartyFromTravelAddress handles API response back to user.
-			return nil, err
-		}
-		return vasp, nil
-
-	case enum.ProtocolTRP:
-		// Lookup the counterparty by travel address
-		if vasp, err = s.CounterpartyFromTravelAddress(c, in.TravelAddress); err != nil {
-			// NOTE: CounterpartyFromTravelAddress handles API response back to user.
-			return nil, err
-		}
-		return vasp, nil
-
-	case enum.ProtocolSunrise:
-		// Get or create the counterparty for the associated email address
-		if vasp, err = s.store.GetOrCreateSunriseCounterparty(ctx, in.EmailAddress, in.Counterparty); err != nil {
 			c.Error(err)
-			c.JSON(http.StatusConflict, api.Error("could not find or create a counterparty with the specified name and/or email address"))
+			c.JSON(http.StatusInternalServerError, api.Error("could not identify counterparty from routing information"))
 			return nil, err
 		}
-		return vasp, nil
+	} else {
+		// If there was no counterparty ID given, then try the backup methods for lookup on a per-protocol basis
+		switch protocol {
+		case enum.ProtocolTRISA:
+			// Lookup the counterparty by travel address
+			if vasp, err = s.CounterpartyFromTravelAddress(c, in.TravelAddress); err != nil {
+				// NOTE: CounterpartyFromTravelAddress handles API response back to user.
+				return nil, err
+			}
 
-	default:
-		// If we get here the protocol is valid but not handled, so this is a developer
-		// bug that we need to fix ASAP, hence the panic.
-		panic(fmt.Errorf("unhandled protocol in resolve counterparty: %q", protocol.String()))
+		case enum.ProtocolTRP:
+			// Lookup the counterparty by travel address
+			if vasp, err = s.CounterpartyFromTravelAddress(c, in.TravelAddress); err != nil {
+				// NOTE: CounterpartyFromTravelAddress handles API response back to user.
+				return nil, err
+			}
+
+		case enum.ProtocolSunrise:
+			// Get or create the counterparty for the associated email address and/or name
+			if vasp, err = s.store.GetOrCreateSunriseCounterparty(ctx, in.EmailAddress, in.Counterparty); err != nil {
+				c.Error(err)
+				c.JSON(http.StatusConflict, api.Error("could not find or create a counterparty with the specified name and/or email address"))
+				return nil, err
+			}
+
+		default:
+			// If we get here the protocol is valid but not handled, so this is a developer
+			// bug that we need to fix ASAP, hence the panic.
+			panic(fmt.Errorf("unhandled protocol in resolve counterparty: %q", protocol.String()))
+		}
+	}
+
+	// If the counterparty protocol matches the request protocol then return it, otherwise return an error code
+	if vasp != nil && protocol == vasp.Protocol {
+		return vasp, nil
+	} else {
+		msg := "the counterparty found for the given ID did not match the requested protocol"
+		c.JSON(http.StatusConflict, api.Error(msg))
+		return nil, errors.New(msg)
 	}
 }
 

--- a/pkg/web/routing.go
+++ b/pkg/web/routing.go
@@ -77,13 +77,17 @@ func (s *Server) ResolveCounterparty(c *gin.Context, in *api.Routing) (vasp *mod
 		}
 	}
 
-	// If the counterparty protocol matches the request protocol then return it, otherwise return an error code
-	if vasp != nil && protocol == vasp.Protocol {
+	switch {
+		// If vasp is nil we probably shouldn't have made it this far in the code, but protecting ourselves anyway.
+		case vasp == nil:
+			c.JSON(http.StatusNotFound, api.Error("could not identify counterparty from routing information"))
+			return nil, errors.New("unhandled nil vasp at end of resolve counterparty")
+		case vasp.Protocol != protocol:
+			err := errors.New("could not find counterparty that supports requested protocol")
+			c.JSON(http.StatusNotFound, api.Error(err)
+			return nil, err
+		default:
 		return vasp, nil
-	} else {
-		msg := "the counterparty found for the given ID did not match the requested protocol"
-		c.JSON(http.StatusConflict, api.Error(msg))
-		return nil, errors.New(msg)
 	}
 }
 

--- a/pkg/web/templates/docs/openapi/openapi.json
+++ b/pkg/web/templates/docs/openapi/openapi.json
@@ -2701,13 +2701,13 @@
           "counterparty_id": {
             "type": "string",
             "format": "ulid",
-            "description": "For the TRISA protocol, submit either the travel address or the VASP counterparty ID to identify the VASP (mutually exclusive with all non-protocol fields).",
+            "description": "Lookup the counterparty by its Envoy specific ID. If this is included, the endpoint will ignore the other optional lookup fields. If the counterparty in Envoy with this ID has a different protocol than included in the routing for this request, then it will fail.",
             "example": "01JPMJG3ZFSX753ZAKRWRZPWVC"
           },
           "travel_address": {
             "type": "string",
             "format": "TravelAddress",
-            "description": "Optional for TRISA and required for TRP, the travel address of the recipient or counterparty VASP.",
+            "description": "Optional for TRISA and TRP, the travel address of the recipient or counterparty VASP.",
             "example": "taLg4sBFp3cWhB9wN7qsiUF8pxo7JXtVShYkv5ix1wG2kX5y4pRiJ3TRHmeD8H67TLLm5wHyDktVw1onfDeQfESumf91mjRTMbi"
           },
           "counterparty": {
@@ -2717,7 +2717,7 @@
           },
           "email": {
             "type": "string",
-            "description": "Required for the Sunrise protocol, the email address of the compliance contact at the counterparty to send the Sunrise message to. May contain a name and bracketed email.",
+            "description": "Optional for the Sunrise protocol, the email address of the compliance contact at the counterparty to send the Sunrise message to. May contain a name and bracketed email.",
             "example": "Jane Smith <jane@alicecoin.com>"
           }
         },

--- a/pkg/web/templates/docs/openapi/openapi.yaml
+++ b/pkg/web/templates/docs/openapi/openapi.yaml
@@ -2303,15 +2303,18 @@ components:
         counterparty_id:
           type: string
           format: ulid
-          description: For the TRISA protocol, submit either the travel address or the VASP
-            counterparty ID to identify the VASP (mutually exclusive with all
-            non-protocol fields).
+          description:
+            Lookup the counterparty by its Envoy specific ID. If this is included,
+            the endpoint will ignore the other optional lookup fields. If the
+            counterparty in Envoy with this ID has a different protocol than
+            included in the routing for this request, then it will fail.
           example: 01JPMJG3ZFSX753ZAKRWRZPWVC
         travel_address:
           type: string
           format: TravelAddress
-          description: Optional for TRISA and required for TRP, the travel address of the
-            recipient or counterparty VASP.
+          description:
+            Optional for TRISA and TRP, the travel address of the recipient or
+            counterparty VASP.
           example: taLg4sBFp3cWhB9wN7qsiUF8pxo7JXtVShYkv5ix1wG2kX5y4pRiJ3TRHmeD8H67TLLm5wHyDktVw1onfDeQfESumf91mjRTMbi
         counterparty:
           type: string
@@ -2322,7 +2325,8 @@ components:
           example: AliceCoin, LLC
         email:
           type: string
-          description: Required for the Sunrise protocol, the email address of the
+          description:
+            Optional for the Sunrise protocol, the email address of the
             compliance contact at the counterparty to send the Sunrise message
             to. May contain a name and bracketed email.
           example: Jane Smith <jane@alicecoin.com>


### PR DESCRIPTION
### Scope of changes

The primary method for looking up a Counterparty for any protocol will be the CounterpartyID, with the travel address and name/email being backups for the currently implemented protocols. If the counterparty found does not match the routing protocol requested, then the user will receive an error.

### Type of change

- [ ] bug fix
- [x] new feature
- [x] documentation
- [ ] other (describe)

### Acceptance criteria

No special requirements.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


