### PR TITLE
Update contacts when possible during `daybreak:import` command

### DIFF
--- a/cmd/envoy/main.go
+++ b/cmd/envoy/main.go
@@ -539,7 +539,8 @@ func daybreakImport(c *cli.Context) (err error) {
 	}
 
 	// Create outer context for database interactions and source info.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// NOTE: 30 seconds should be enough for several thousand entries, otherwise increase it.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// NOTE: this operation happens in its own transaction, if two daybreak imports
@@ -594,10 +595,7 @@ func daybreakImport(c *cli.Context) (err error) {
 		}
 
 		if len(contacts) == 0 {
-			// TODO: we could create a CLI flag to ignore counterparties with no contacts
-			// if we wanted to force import them. However by default, not importing a
-			// counterparty without contacts is better since they won't be able to do
-			// sunrise without an email address.
+			// Daybreak counterparties should always have contacts, otherwise where do emails go?
 			log.Warn().Str("directory_id", apiCounterparty.DirectoryID).Str("name", apiCounterparty.Name).Msg("counterparty has no contacts")
 			continue
 		}

--- a/pkg/store/mock/store.go
+++ b/pkg/store/mock/store.go
@@ -172,7 +172,7 @@ func (s *Store) DeleteCounterparty(ctx context.Context, counterpartyID ulid.ULID
 	return nil
 }
 
-func (s *Store) ListContacts(ctx context.Context, counterpartyID ulid.ULID, page *models.PageInfo) (*models.ContactsPage, error) {
+func (s *Store) ListContacts(ctx context.Context, counterparty any, page *models.PageInfo) (*models.ContactsPage, error) {
 	return nil, nil
 }
 
@@ -180,7 +180,7 @@ func (s *Store) CreateContact(context.Context, *models.Contact) error {
 	return nil
 }
 
-func (s *Store) RetrieveContact(ctx context.Context, contactID, counterpartyID ulid.ULID) (*models.Contact, error) {
+func (s *Store) RetrieveContact(ctx context.Context, contactID, counterparty any) (*models.Contact, error) {
 	return nil, nil
 }
 
@@ -188,7 +188,7 @@ func (s *Store) UpdateContact(context.Context, *models.Contact) error {
 	return nil
 }
 
-func (s *Store) DeleteContact(ctx context.Context, contactID, counterpartyID ulid.ULID) error {
+func (s *Store) DeleteContact(ctx context.Context, contactID, counterparty any) error {
 	return nil
 }
 

--- a/pkg/store/sqlite/counterparty.go
+++ b/pkg/store/sqlite/counterparty.go
@@ -271,18 +271,39 @@ func (s *Store) DeleteCounterparty(ctx context.Context, counterpartyID ulid.ULID
 
 const listContactsSQL = "SELECT * FROM contacts WHERE counterparty_id=:counterpartyID"
 
-// List contacts associated with the specified counterparty.
-func (s *Store) ListContacts(ctx context.Context, counterpartyID ulid.ULID, page *models.PageInfo) (out *models.ContactsPage, err error) {
+// List contacts associated with the specified counterparty. The counterparty can either
+// be a ULID of the counterparty ID or a pointer to the Counterparty model. If the
+// ID is specified then the associated counterparty is retrieved from the database and
+// attached to all returned contacts. If the model is specified, then the contacts,
+// will be attached to the model.
+func (s *Store) ListContacts(ctx context.Context, counterparty any, page *models.PageInfo) (out *models.ContactsPage, err error) {
+	var (
+		counterpartyID    ulid.ULID
+		counterpartyModel *models.Counterparty
+	)
+
+	if counterparty == nil {
+		return nil, dberr.ErrMissingAssociation
+	}
+
 	var tx *sql.Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	// Check to ensure the associated counterparty exists
-	var counterparty *models.Counterparty
-	if counterparty, err = retrieveCounterparty(tx, counterpartyID); err != nil {
-		return nil, err
+	// Handle the input counterparty and retrieve the counterparty model if necessary.
+	switch c := counterparty.(type) {
+	case *models.Counterparty:
+		counterpartyID = c.ID
+		counterpartyModel = c
+	case ulid.ULID:
+		counterpartyID = c
+		if counterpartyModel, err = retrieveCounterparty(tx, counterpartyID); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("invalid type for counterparty: %T", counterparty)
 	}
 
 	// TODO: handle pagination
@@ -303,13 +324,17 @@ func (s *Store) ListContacts(ctx context.Context, counterpartyID ulid.ULID, page
 			return nil, err
 		}
 
-		contact.SetCounterparty(counterparty)
+		contact.SetCounterparty(counterpartyModel)
 		out.Contacts = append(out.Contacts, contact)
 	}
 
 	if errors.Is(rows.Err(), sql.ErrNoRows) {
 		return nil, dberr.ErrNotFound
 	}
+
+	// Associate the contacts with the counterparty model (useful if a pointer to
+	// a counterparty was passed in).
+	counterpartyModel.SetContacts(out.Contacts)
 
 	tx.Commit()
 	return out, nil
@@ -335,28 +360,6 @@ func (s *Store) listContacts(tx *sql.Tx, counterparty *models.Counterparty) (err
 
 	counterparty.SetContacts(contacts)
 	return nil
-}
-
-// Returns a mapping of Contacts using their email as the keys; useful for comparing contacts we need to update/create.
-func (s *Store) listMapCounterpartyContactsByEmail(tx *sql.Tx, counterpartyID ulid.ULID) (contacts map[string]*models.Contact, err error) {
-	var rows *sql.Rows
-	if rows, err = tx.Query(listContactsSQL, sql.Named("counterpartyID", counterpartyID)); err != nil {
-		return nil, dbe(err)
-	}
-	defer rows.Close()
-
-	contacts = make(map[string]*models.Contact)
-	for rows.Next() {
-		contact := &models.Contact{}
-		if err = contact.Scan(rows); err != nil {
-			return nil, err
-		}
-
-		contact.CounterpartyID = counterpartyID
-		contacts[contact.Email] = contact
-	}
-
-	return contacts, nil
 }
 
 const createContactSQL = "INSERT INTO contacts (id, name, email, role, counterparty_id, created, modified) VALUES (:id, :name, :email, :role, :counterpartyID, :created, :modified)"
@@ -392,17 +395,47 @@ func (s *Store) createContact(tx *sql.Tx, contact *models.Contact) (err error) {
 	if _, err = tx.Exec(createContactSQL, contact.Params()...); err != nil {
 		return dbe(err)
 	}
+
 	return nil
 }
 
 const retrieveContactSQL = "SELECT * FROM contacts WHERE id=:id and counterparty_id=:counterpartyID"
 
-func (s *Store) RetrieveContact(ctx context.Context, contactID, counterpartyID ulid.ULID) (contact *models.Contact, err error) {
+// Retrieve the contact with the specified ID and associate it with the
+// specified counterparty. The counterparty can either be the ULID of the counterparty
+// or a pointer to the Counterparty model. If the ID is specified then the
+// associated counterparty is retrieved from the database and attached to the
+// contact. Note that if a pointer to the Counterparty model is specified, it is not
+// modified in place.
+func (s *Store) RetrieveContact(ctx context.Context, contactID, counterparty any) (contact *models.Contact, err error) {
+	var (
+		counterpartyID    ulid.ULID
+		counterpartyModel *models.Counterparty
+	)
+
+	if counterparty == nil {
+		return nil, dberr.ErrMissingAssociation
+	}
+
 	var tx *sql.Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
+
+	// Handle the input counterparty and retrieve the counterparty model if necessary.
+	switch c := counterparty.(type) {
+	case *models.Counterparty:
+		counterpartyID = c.ID
+		counterpartyModel = c
+	case ulid.ULID:
+		counterpartyID = c
+		if counterpartyModel, err = retrieveCounterparty(tx, counterpartyID); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("invalid type for counterparty: %T", counterparty)
+	}
 
 	// Retrieve the contact
 	contact = &models.Contact{}
@@ -410,12 +443,8 @@ func (s *Store) RetrieveContact(ctx context.Context, contactID, counterpartyID u
 		return nil, dbe(err)
 	}
 
-	// Retrieve and associate the Counterparty
-	var counterparty *models.Counterparty
-	if counterparty, err = retrieveCounterparty(tx, counterpartyID); err != nil {
-		return nil, err
-	}
-	contact.SetCounterparty(counterparty)
+	// Associate the contact with the counterparty model.
+	contact.SetCounterparty(counterpartyModel)
 
 	tx.Commit()
 	return contact, nil
@@ -473,18 +502,55 @@ func (s *Store) updateContact(tx *sql.Tx, contact *models.Contact) (err error) {
 
 const deleteContact = "DELETE FROM contacts WHERE id=:id AND counterparty_id=:counterpartyID"
 
-func (s *Store) DeleteContact(ctx context.Context, contactID, counterpartyID ulid.ULID) (err error) {
+// Delete contact associated with the specified counterparty. The counterparty can
+// either be a ULID of the counterparty or a pointer to the Counterparty model. If the
+// ID is specified then the associated counterparty is used to identify the contact to
+// delete. If the model is specified, then the contact is deleted from the model as well.
+func (s *Store) DeleteContact(ctx context.Context, contactID, counterparty any) (err error) {
+	var (
+		counterpartyID    ulid.ULID
+		counterpartyModel *models.Counterparty
+	)
+
+	if counterparty == nil {
+		return dberr.ErrMissingAssociation
+	}
+
 	var tx *sql.Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
+	// Handle the input counterparty.
+	switch c := counterparty.(type) {
+	case *models.Counterparty:
+		counterpartyID = c.ID
+		counterpartyModel = c
+	case ulid.ULID:
+		counterpartyID = c
+	default:
+		return fmt.Errorf("invalid type for counterparty: %T", counterparty)
+	}
+
 	var result sql.Result
 	if result, err = tx.Exec(deleteContact, sql.Named("id", contactID), sql.Named("counterpartyID", counterpartyID)); err != nil {
 		return dbe(err)
 	} else if nRows, _ := result.RowsAffected(); nRows == 0 {
 		return dberr.ErrNotFound
+	}
+
+	// If a counterparty model was passed in, update its contacts to delete the deleted contact.
+	if counterpartyModel != nil {
+		if contacts, cerr := counterpartyModel.Contacts(); cerr == nil {
+			// Remove the contact from the counterparty model
+			for i, contact := range contacts {
+				if contact.ID == contactID {
+					counterpartyModel.SetContacts(append(contacts[:i], contacts[i+1:]...))
+					break
+				}
+			}
+		}
 	}
 
 	return tx.Commit()

--- a/pkg/store/sqlite/daybreak.go
+++ b/pkg/store/sqlite/daybreak.go
@@ -63,7 +63,7 @@ func (s *Store) CreateDaybreak(ctx context.Context, counterparty *models.Counter
 					} else {
 						// If no error occurred, then we fixed the original counterparty
 						// Need to commit and return here to short-circuit error handling
-						log.Info().Str("directory_id", counterparty.DirectoryID.String).Msg("fixed original counterparty that was not returned in source info (a rare edge case)")
+						log.Debug().Str("directory_id", counterparty.DirectoryID.String).Msg("fixed original counterparty that was not returned in source info (a rare edge case)")
 						return tx.Commit()
 					}
 				}

--- a/pkg/store/sqlite/daybreak.go
+++ b/pkg/store/sqlite/daybreak.go
@@ -119,13 +119,15 @@ func (s *Store) updateDaybreak(tx *sql.Tx, counterparty *models.Counterparty) (e
 		}
 		if err = s.createContact(tx, contact); err != nil {
 			if errors.Is(err, dberr.ErrAlreadyExists) {
-				// TODO: get the contact's ID and update it if it is associated with the
-				// counterparty (otherwise error). (This improvement has a ticket already)
-				continue // silence these specific errors until we deal with the update ticket
+				if err = s.updateContact(tx, contact); err != nil {
+					log.Warn().Err(err).Str("counterparty", counterparty.ID.String()).Str("contact", contact.Email).Msg("could not update contact")
+					return err
+				}
+			} else {
+				log.Warn().Err(err).Str("counterparty", counterparty.ID.String()).Str("contact", contact.Email).Msg("could not create contact")
+				return err
 			}
 
-			log.Warn().Err(err).Str("counterparty", counterparty.ID.String()).Str("contact", contact.Email).Msg("could not create contact")
-			return err
 		}
 	}
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -140,11 +140,11 @@ type CounterpartyStore interface {
 }
 
 type ContactStore interface {
-	ListContacts(ctx context.Context, counterpartyID ulid.ULID, page *models.PageInfo) (*models.ContactsPage, error)
+	ListContacts(ctx context.Context, counterparty any, page *models.PageInfo) (*models.ContactsPage, error)
 	CreateContact(context.Context, *models.Contact) error
-	RetrieveContact(ctx context.Context, contactID, counterpartyID ulid.ULID) (*models.Contact, error)
+	RetrieveContact(ctx context.Context, contactID, counterpartyID any) (*models.Contact, error)
 	UpdateContact(context.Context, *models.Contact) error
-	DeleteContact(ctx context.Context, contactID, counterpartyID ulid.ULID) error
+	DeleteContact(ctx context.Context, contactID, counterpartyID any) error
 }
 
 type TravelAddressStore interface {


### PR DESCRIPTION
### Scope of changes

Contacts are now updated alongside Counterparties in the `daybreak:import` command. Also, Counterparties are now associated with Contacts when retrieving contacts.

### Type of change

- [x] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Please try to run this against the testnet node with the newest Daybreak JSON @bbengfort (I will send it to you).

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


