### PR TITLE
Use Cookie for Reset Password Token

### DIFF
--- a/pkg/web/cookies.go
+++ b/pkg/web/cookies.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/trisacrypto/envoy/pkg/web/auth"
+)
+
+const (
+	ResetPasswordTokenCookie = "reset_password_token"
+	ResetPasswordPath        = "/v1/reset-password"
+	ResetPasswordTokenTTL    = 15 * time.Minute
+)
+
+func (s *Server) SetCookie(c *gin.Context, name, value, path string, maxAge int, httpOnly bool) {
+	domain := s.conf.Web.Auth.CookieDomain
+	secure := !auth.IsLocalhost(domain)
+
+	c.SetCookie(name, value, maxAge, path, domain, secure, httpOnly)
+}
+
+func (s *Server) ClearCookie(c *gin.Context, name, path string, httpOnly bool) {
+	s.SetCookie(c, name, "", path, -1, httpOnly)
+}
+
+func (s *Server) SetResetPasswordTokenCookie(c *gin.Context, token string) {
+	s.SetCookie(c, ResetPasswordTokenCookie, token, ResetPasswordPath, int(ResetPasswordTokenTTL.Seconds()), true)
+}
+
+func (s *Server) ClearResetPasswordTokenCookie(c *gin.Context) {
+	s.ClearCookie(c, ResetPasswordTokenCookie, ResetPasswordPath, true)
+}
+
+func setToastCookie(c *gin.Context, name, value, path, domain string) {
+	secure := !auth.IsLocalhost(domain)
+	c.SetCookie(name, value, 1, path, domain, secure, false)
+}

--- a/pkg/web/pages.go
+++ b/pkg/web/pages.go
@@ -65,12 +65,14 @@ func (s *Server) ResetPasswordPage(c *gin.Context) {
 		log.Debug().Err(err).Msg("could not parse query string")
 	}
 
-	// Set the scene (we pass the token on from the verify/change page)
-	tokenScene := scene.New(c)
-	tokenScene["Token"] = in.Token
+	// Set the token into a cookie so that it can be parsed when the form is submitted.
+	// A cookie is more secure than using a hidden form because it cannot be accessed
+	// by XSS attacks (though it could be fetched by the window.location object).
+	// NOTE: no verification is performed here, just on reset-password.
+	s.SetResetPasswordTokenCookie(c, in.Token)
 
 	// Render the verify and change page
-	c.HTML(http.StatusOK, "auth/reset/password.html", tokenScene)
+	c.HTML(http.StatusOK, "auth/reset/password.html", scene.New(c))
 }
 
 //===========================================================================

--- a/pkg/web/templates/auth/reset/password.html
+++ b/pkg/web/templates/auth/reset/password.html
@@ -45,7 +45,7 @@
               <li>Minimum 8 characters</li>
               <li>Both upper and lower case letters</li>
               <li>At least one number</li>
-              <li>Can’t be the same as previous password</li>
+              <li>Can&apos;t be the same as previous password</li>
               <li>Special characters recommended</li>
             </ul>
           </div>
@@ -54,8 +54,6 @@
       <div class="col-12 col-md-6 col-xl-4 mb-5">
         <!-- change password form -->
         <form hx-post="/v1/reset-password" hx-ext='json-enc' hx-headers='{"Accept": "text/html"}' hx-swap="innerHTML" hx-target="#success" hx-trigger="submit">
-          <input type="hidden" id="token" name="token" value="{{ .Token }}">
-
           <div class="form-group">
             <label class="form-label" for="password">New password</label>
             <div class="input-group input-group-merge">

--- a/pkg/web/transactions.go
+++ b/pkg/web/transactions.go
@@ -13,7 +13,6 @@ import (
 	dberr "github.com/trisacrypto/envoy/pkg/store/errors"
 	"github.com/trisacrypto/envoy/pkg/store/models"
 	"github.com/trisacrypto/envoy/pkg/web/api/v1"
-	"github.com/trisacrypto/envoy/pkg/web/auth"
 	"github.com/trisacrypto/envoy/pkg/web/htmx"
 	"github.com/trisacrypto/envoy/pkg/web/scene"
 	trisa "github.com/trisacrypto/trisa/pkg/trisa/api/v1beta1"
@@ -1345,9 +1344,4 @@ func CheckUUIDMatch(id, target uuid.UUID) error {
 	}
 
 	return nil
-}
-
-func setToastCookie(c *gin.Context, name, value, path, domain string) {
-	secure := !auth.IsLocalhost(domain)
-	c.SetCookie(name, value, 1, path, domain, secure, false)
 }


### PR DESCRIPTION
### Scope of changes

Instead of using a hidden form field; store the token in a cookie to prevent XSS attacks.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation