### PR TITLE
Store Transaction Interface

### DIFF
--- a/cmd/envoy/main.go
+++ b/cmd/envoy/main.go
@@ -277,7 +277,7 @@ func remigrate(c *cli.Context) (err error) {
 
 	var (
 		srcdb, dstdb *sqlite.Store
-		srctx, dsttx *sql.Tx
+		srctx, dsttx *sqlite.Tx
 	)
 
 	// Connect to both databases
@@ -719,7 +719,7 @@ func closeDB(c *cli.Context) error {
 	return nil
 }
 
-func connectSqlite3(path string) (dbs *sqlite.Store, tx *sql.Tx, err error) {
+func connectSqlite3(path string) (dbs *sqlite.Store, tx *sqlite.Tx, err error) {
 	var db store.Store
 	if db, err = store.Open("sqlite3:///" + path); err != nil {
 		return nil, nil, err
@@ -733,7 +733,7 @@ func connectSqlite3(path string) (dbs *sqlite.Store, tx *sql.Tx, err error) {
 	return dbs, tx, nil
 }
 
-func sqlite3Tables(tx *sql.Tx) (tables []string, err error) {
+func sqlite3Tables(tx *sqlite.Tx) (tables []string, err error) {
 	tables = make([]string, 0)
 
 	var rows *sql.Rows

--- a/pkg/store/mock/store.go
+++ b/pkg/store/mock/store.go
@@ -26,7 +26,7 @@ func (s *Store) Close() error {
 	return nil
 }
 
-func (s *Store) Begin(ctx context.Context, opts *sql.TxOptions) (txn.Tx, error) {
+func (s *Store) Begin(ctx context.Context, opts *sql.TxOptions) (txn.Txn, error) {
 	return &Tx{}, nil
 }
 

--- a/pkg/store/mock/store.go
+++ b/pkg/store/mock/store.go
@@ -2,11 +2,13 @@ package mock
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/trisacrypto/envoy/pkg/enum"
 	"github.com/trisacrypto/envoy/pkg/store/dsn"
 	"github.com/trisacrypto/envoy/pkg/store/models"
+	"github.com/trisacrypto/envoy/pkg/store/txn"
 
 	"github.com/google/uuid"
 	"go.rtnl.ai/ulid"
@@ -22,6 +24,10 @@ func Open(uri *dsn.DSN) (*Store, error) {
 
 func (s *Store) Close() error {
 	return nil
+}
+
+func (s *Store) Begin(ctx context.Context, opts *sql.TxOptions) (txn.Tx, error) {
+	return &Tx{}, nil
 }
 
 func (s *Store) ListTransactions(context.Context, *models.TransactionPageInfo) (*models.TransactionPage, error) {

--- a/pkg/store/mock/tx.go
+++ b/pkg/store/mock/tx.go
@@ -1,5 +1,15 @@
 package mock
 
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/trisacrypto/envoy/pkg/enum"
+	"github.com/trisacrypto/envoy/pkg/store/models"
+	"go.rtnl.ai/ulid"
+)
+
 type Tx struct{}
 
 func (tx *Tx) Commit() error {
@@ -7,5 +17,285 @@ func (tx *Tx) Commit() error {
 }
 
 func (tx *Tx) Rollback() error {
+	return nil
+}
+
+func (tx *Tx) ListTransactions(*models.TransactionPageInfo) (*models.TransactionPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateTransaction(*models.Transaction) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveTransaction(uuid.UUID) (*models.Transaction, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateTransaction(*models.Transaction) error {
+	return nil
+}
+
+func (tx *Tx) DeleteTransaction(uuid.UUID) error {
+	return nil
+}
+
+func (tx *Tx) ArchiveTransaction(uuid.UUID) error {
+	return nil
+}
+
+func (tx *Tx) UnarchiveTransaction(uuid.UUID) error {
+	return nil
+}
+
+func (tx *Tx) CountTransactions() (*models.TransactionCounts, error) {
+	return nil, nil
+}
+
+func (tx *Tx) TransactionState(uuid.UUID) (archived bool, status enum.Status, err error) {
+	return false, enum.StatusUnspecified, nil
+}
+
+func (tx *Tx) ListSecureEnvelopes(txID uuid.UUID, page *models.PageInfo) (*models.SecureEnvelopePage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateSecureEnvelope(*models.SecureEnvelope) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveSecureEnvelope(txID uuid.UUID, envID ulid.ULID) (*models.SecureEnvelope, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateSecureEnvelope(*models.SecureEnvelope) error {
+	return nil
+}
+
+func (tx *Tx) DeleteSecureEnvelope(txID uuid.UUID, envID ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) LatestSecureEnvelope(txID uuid.UUID, direction enum.Direction) (*models.SecureEnvelope, error) {
+	return nil, nil
+}
+
+func (tx *Tx) LatestPayloadEnvelope(txID uuid.UUID, direction enum.Direction) (*models.SecureEnvelope, error) {
+	return nil, nil
+}
+
+func (tx *Tx) ListAccounts(page *models.PageInfo) (*models.AccountsPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateAccount(*models.Account) error {
+	return nil
+}
+
+func (tx *Tx) LookupAccount(cryptoAddress string) (*models.Account, error) {
+	return nil, nil
+}
+
+func (tx *Tx) RetrieveAccount(id ulid.ULID) (*models.Account, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateAccount(*models.Account) error {
+	return nil
+}
+
+func (tx *Tx) DeleteAccount(id ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) ListAccountTransactions(accountID ulid.ULID, page *models.TransactionPageInfo) (*models.TransactionPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) ListCryptoAddresses(accountID ulid.ULID, page *models.PageInfo) (*models.CryptoAddressPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateCryptoAddress(*models.CryptoAddress) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveCryptoAddress(accountID, cryptoAddressID ulid.ULID) (*models.CryptoAddress, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateCryptoAddress(*models.CryptoAddress) error {
+	return nil
+}
+
+func (tx *Tx) DeleteCryptoAddress(accountID, cryptoAddressID ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) SearchCounterparties(query *models.SearchQuery) (*models.CounterpartyPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) ListCounterparties(page *models.CounterpartyPageInfo) (*models.CounterpartyPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) ListCounterpartySourceInfo(source enum.Source) ([]*models.CounterpartySourceInfo, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateCounterparty(*models.Counterparty) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveCounterparty(counterpartyID ulid.ULID) (*models.Counterparty, error) {
+	return nil, nil
+}
+
+func (tx *Tx) LookupCounterparty(field, value string) (*models.Counterparty, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateCounterparty(*models.Counterparty) error {
+	return nil
+}
+
+func (tx *Tx) DeleteCounterparty(counterpartyID ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) ListContacts(counterparty any, page *models.PageInfo) (*models.ContactsPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateContact(*models.Contact) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveContact(contactID, counterpartyID any) (*models.Contact, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateContact(*models.Contact) error {
+	return nil
+}
+
+func (tx *Tx) DeleteContact(contactID, counterpartyID any) error {
+	return nil
+}
+
+func (tx *Tx) ListSunrise(*models.PageInfo) (*models.SunrisePage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateSunrise(*models.Sunrise) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveSunrise(ulid.ULID) (*models.Sunrise, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateSunrise(*models.Sunrise) error {
+	return nil
+}
+
+func (tx *Tx) UpdateSunriseStatus(uuid.UUID, enum.Status) error {
+	return nil
+}
+
+func (tx *Tx) DeleteSunrise(ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) GetOrCreateSunriseCounterparty(email, name string) (*models.Counterparty, error) {
+	return nil, nil
+}
+
+func (tx *Tx) ListUsers(page *models.UserPageInfo) (*models.UserPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateUser(*models.User) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveUser(emailOrUserID any) (*models.User, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateUser(*models.User) error {
+	return nil
+}
+
+func (tx *Tx) SetUserPassword(userID ulid.ULID, password string) error {
+	return nil
+}
+
+func (tx *Tx) SetUserLastLogin(userID ulid.ULID, lastLogin time.Time) error {
+	return nil
+}
+
+func (tx *Tx) DeleteUser(userID ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) LookupRole(role string) (*models.Role, error) {
+	return nil, nil
+}
+
+func (tx *Tx) ListAPIKeys(*models.PageInfo) (*models.APIKeyPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateAPIKey(*models.APIKey) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveAPIKey(clientIDOrKeyID any) (*models.APIKey, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateAPIKey(*models.APIKey) error {
+	return nil
+}
+
+func (tx *Tx) DeleteAPIKey(keyID ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) ListResetPasswordLinks(*models.PageInfo) (*models.ResetPasswordLinkPage, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateResetPasswordLink(*models.ResetPasswordLink) error {
+	return nil
+}
+
+func (tx *Tx) RetrieveResetPasswordLink(ulid.ULID) (*models.ResetPasswordLink, error) {
+	return nil, nil
+}
+
+func (tx *Tx) UpdateResetPasswordLink(*models.ResetPasswordLink) error {
+	return nil
+}
+
+func (tx *Tx) DeleteResetPasswordLink(ulid.ULID) error {
+	return nil
+}
+
+func (tx *Tx) ListDaybreak(ctx context.Context) (map[string]*models.CounterpartySourceInfo, error) {
+	return nil, nil
+}
+
+func (tx *Tx) CreateDaybreak(counterparty *models.Counterparty) error {
+	return nil
+}
+
+func (tx *Tx) UpdateDaybreak(counterparty *models.Counterparty) error {
+	return nil
+}
+
+func (tx *Tx) DeleteDaybreak(counterpartyID ulid.ULID, ignoreTxns bool) error {
 	return nil
 }

--- a/pkg/store/mock/tx.go
+++ b/pkg/store/mock/tx.go
@@ -1,0 +1,11 @@
+package mock
+
+type Tx struct{}
+
+func (tx *Tx) Commit() error {
+	return nil
+}
+
+func (tx *Tx) Rollback() error {
+	return nil
+}

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/trisacrypto/envoy/pkg/store/dsn"
 	"github.com/trisacrypto/envoy/pkg/store/errors"
 	"github.com/trisacrypto/envoy/pkg/store/models"
+	"github.com/trisacrypto/envoy/pkg/store/txn"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -18,6 +19,13 @@ type Store struct {
 	readonly bool
 	conn     *sql.DB
 	mkta     models.TravelAddressFactory
+}
+
+// Tx implements the store.Tx interface using SQLite3 as the storage backend.
+type Tx struct {
+	tx   *sql.Tx
+	opts *sql.TxOptions
+	mkta models.TravelAddressFactory
 }
 
 func Open(uri *dsn.DSN) (_ *Store, err error) {
@@ -67,7 +75,11 @@ func (s *Store) Close() error {
 	return s.conn.Close()
 }
 
-func (s *Store) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx *sql.Tx, err error) {
+func (s *Store) Begin(ctx context.Context, opts *sql.TxOptions) (txn.Tx, error) {
+	return s.BeginTx(ctx, opts)
+}
+
+func (s *Store) BeginTx(ctx context.Context, opts *sql.TxOptions) (_ *Tx, err error) {
 	// Ensure the options respect the read-only option specified by the user.
 	if opts == nil {
 		opts = &sql.TxOptions{ReadOnly: s.readonly}
@@ -75,8 +87,12 @@ func (s *Store) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx *sql.Tx, e
 		return nil, errors.ErrReadOnly
 	}
 
-	// Create a transaction with the specified context.
-	return s.conn.BeginTx(ctx, opts)
+	var tx *sql.Tx
+	if tx, err = s.conn.BeginTx(ctx, opts); err != nil {
+		return nil, err
+	}
+
+	return &Tx{tx: tx, opts: opts, mkta: s.mkta}, nil
 }
 
 func (s *Store) UseTravelAddressFactory(f models.TravelAddressFactory) {
@@ -85,4 +101,28 @@ func (s *Store) UseTravelAddressFactory(f models.TravelAddressFactory) {
 
 func (s *Store) Stats() sql.DBStats {
 	return s.conn.Stats()
+}
+
+//===========================================================================
+// Tx methods
+//===========================================================================
+
+func (t *Tx) Commit() error {
+	return t.tx.Commit()
+}
+
+func (t *Tx) Rollback() error {
+	return t.tx.Rollback()
+}
+
+func (t *Tx) Query(query string, args ...any) (*sql.Rows, error) {
+	return t.tx.Query(query, args...)
+}
+
+func (t *Tx) QueryRow(query string, args ...any) *sql.Row {
+	return t.tx.QueryRow(query, args...)
+}
+
+func (t *Tx) Exec(query string, args ...any) (sql.Result, error) {
+	return t.tx.Exec(query, args...)
 }

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -75,7 +75,7 @@ func (s *Store) Close() error {
 	return s.conn.Close()
 }
 
-func (s *Store) Begin(ctx context.Context, opts *sql.TxOptions) (txn.Tx, error) {
+func (s *Store) Begin(ctx context.Context, opts *sql.TxOptions) (txn.Txn, error) {
 	return s.BeginTx(ctx, opts)
 }
 

--- a/pkg/store/sqlite/transactions.go
+++ b/pkg/store/sqlite/transactions.go
@@ -23,12 +23,23 @@ import (
 const listTransactionsSQL = "SELECT t.id, t.source, t.status, t.counterparty, t.counterparty_id, t.originator, t.originator_address, t.beneficiary, t.beneficiary_address, t.virtual_asset, t.amount, t.archived, t.archived_on, t.last_update, t.modified, t.created, count(e.id) AS numEnvelopes FROM transactions t LEFT JOIN secure_envelopes e ON t.id=e.envelope_id WHERE t.archived=:archives GROUP BY t.id ORDER BY t.created DESC"
 
 func (s *Store) ListTransactions(ctx context.Context, page *models.TransactionPageInfo) (out *models.TransactionPage, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
+	if out, err = tx.ListTransactions(page); err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (t *Tx) ListTransactions(page *models.TransactionPageInfo) (out *models.TransactionPage, err error) {
 	out = &models.TransactionPage{
 		Transactions: make([]*models.Transaction, 0),
 		Page: &models.TransactionPageInfo{
@@ -63,7 +74,7 @@ func (s *Store) ListTransactions(ctx context.Context, page *models.TransactionPa
 	}
 
 	var rows *sql.Rows
-	if rows, err = tx.Query(query, params...); err != nil {
+	if rows, err = t.tx.Query(query, params...); err != nil {
 		return nil, dbe(err)
 	}
 	defer rows.Close()
@@ -76,23 +87,30 @@ func (s *Store) ListTransactions(ctx context.Context, page *models.TransactionPa
 		out.Transactions = append(out.Transactions, transaction)
 	}
 
-	tx.Commit()
 	return out, nil
 }
 
 const createTransactionSQL = "INSERT INTO transactions (id, source, status, counterparty, counterparty_id, originator, originator_address, beneficiary, beneficiary_address, virtual_asset, amount, archived, archived_on, last_update, created, modified) VALUES (:id, :source, :status, :counterparty, :counterpartyID, :originator, :originatorAddress, :beneficiary, :beneficiaryAddress, :virtualAsset, :amount, :archived, :archivedOn, :lastUpdate, :created, :modified)"
 
 func (s *Store) CreateTransaction(ctx context.Context, transaction *models.Transaction) (err error) {
-	// Basic validation
-	if transaction.ID != uuid.Nil {
-		return dberr.ErrNoIDOnCreate
-	}
-
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return err
 	}
 	defer tx.Rollback()
+
+	if err = tx.CreateTransaction(transaction); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (t *Tx) CreateTransaction(transaction *models.Transaction) (err error) {
+	// Basic validation
+	if transaction.ID != uuid.Nil {
+		return dberr.ErrNoIDOnCreate
+	}
 
 	// Create IDs and model metadata, updating the transaction in place
 	transaction.ID = uuid.New()
@@ -100,38 +118,51 @@ func (s *Store) CreateTransaction(ctx context.Context, transaction *models.Trans
 	transaction.Modified = transaction.Created
 
 	// Insert the transaction into the database
-	if _, err = tx.Exec(createTransactionSQL, transaction.Params()...); err != nil {
+	if _, err = t.tx.Exec(createTransactionSQL, transaction.Params()...); err != nil {
 		return dbe(err)
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 const retrieveTransactionSQL = "SELECT id, source, status, counterparty, counterparty_id, originator, originator_address, beneficiary, beneficiary_address, virtual_asset, amount, archived, archived_on, last_update, modified, created FROM transactions WHERE id=:id"
 
+// Retrieve a transaction record by its ID and any related secure envelopes.
 func (s *Store) RetrieveTransaction(ctx context.Context, id uuid.UUID) (transaction *models.Transaction, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	if transaction, err = s.retrieveTransaction(tx, id); err != nil {
+	if transaction, err = tx.RetrieveTransaction(id); err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return transaction, nil
+}
+
+// Retrieve a transaction record by its ID and any related secure envelopes.
+func (t *Tx) RetrieveTransaction(transactionID uuid.UUID) (transaction *models.Transaction, err error) {
+	if transaction, err = t.retrieveTransaction(transactionID); err != nil {
 		return nil, err
 	}
 
 	// Retrieve associated secure envelopes with the transaction
-	if err = s.listSecureEnvelopes(tx, transaction); err != nil {
+	if err = t.associateSecureEnvelopes(transaction); err != nil {
 		return nil, err
 	}
 
-	tx.Commit()
 	return transaction, nil
 }
 
-func (s *Store) retrieveTransaction(tx *sql.Tx, transactionID uuid.UUID) (transaction *models.Transaction, err error) {
+// Retrieve only a transaction record by its ID without associated secure envelopes.
+func (t *Tx) retrieveTransaction(transactionID uuid.UUID) (transaction *models.Transaction, err error) {
 	transaction = &models.Transaction{}
-	if err = transaction.Scan(tx.QueryRow(retrieveTransactionSQL, sql.Named("id", transactionID))); err != nil {
+	if err = transaction.Scan(t.tx.QueryRow(retrieveTransactionSQL, sql.Named("id", transactionID))); err != nil {
 		return nil, dbe(err)
 	}
 	return transaction, nil
@@ -140,25 +171,32 @@ func (s *Store) retrieveTransaction(tx *sql.Tx, transactionID uuid.UUID) (transa
 const updateTransactionSQL = "UPDATE transactions SET source=:source, status=:status, counterparty=:counterparty, counterparty_id=:counterpartyID, originator=:originator, originator_address=:originatorAddress, beneficiary=:beneficiary, beneficiary_address=:beneficiaryAddress, virtual_asset=:virtualAsset, amount=:amount, archived=:archived, archived_on=:archivedOn, last_update=:lastUpdate, modified=:modified WHERE id=:id"
 
 func (s *Store) UpdateTransaction(ctx context.Context, t *models.Transaction) (err error) {
-	// Basic validation
-	if t.ID == uuid.Nil {
-		return dberr.ErrMissingID
-	}
-
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
+	if err = tx.UpdateTransaction(t); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (t *Tx) UpdateTransaction(transaction *models.Transaction) (err error) {
+	// Basic validation
+	if transaction.ID == uuid.Nil {
+		return dberr.ErrMissingID
+	}
+
 	// Update modified timestamp (in place).
-	t.Modified = time.Now()
+	transaction.Modified = time.Now()
 
 	// NOTE: do not update `LastUpdate` timestamp - this refers to when a secure envelope is sent/received.
 
 	// Execute the update into the database
 	var result sql.Result
-	if result, err = tx.Exec(updateTransactionSQL, t.Params()...); err != nil {
+	if result, err = t.tx.Exec(updateTransactionSQL, transaction.Params()...); err != nil {
 		return dbe(err)
 	}
 
@@ -166,20 +204,28 @@ func (s *Store) UpdateTransaction(ctx context.Context, t *models.Transaction) (e
 		return dberr.ErrNotFound
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 const deleteTransactionSQL = "DELETE FROM transactions WHERE id=:id"
 
 func (s *Store) DeleteTransaction(ctx context.Context, id uuid.UUID) (err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
+	if err = tx.DeleteTransaction(id); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (t *Tx) DeleteTransaction(id uuid.UUID) (err error) {
 	var result sql.Result
-	if result, err = tx.Exec(deleteTransactionSQL, sql.Named("id", id)); err != nil {
+	if result, err = t.tx.Exec(deleteTransactionSQL, sql.Named("id", id)); err != nil {
 		return dbe(err)
 	}
 
@@ -187,27 +233,26 @@ func (s *Store) DeleteTransaction(ctx context.Context, id uuid.UUID) (err error)
 		return dberr.ErrNotFound
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 const archiveTransactionSQL = "UPDATE transactions SET archived=:archived, archived_on=:archivedOn, modified=:modified WHERE id=:id"
 
 func (s *Store) ArchiveTransaction(ctx context.Context, transactionID uuid.UUID) (err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
-	if err = s.archiveTransaction(tx, transactionID); err != nil {
+	if err = tx.ArchiveTransaction(transactionID); err != nil {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
-func (s *Store) archiveTransaction(tx *sql.Tx, transactionID uuid.UUID) (err error) {
+func (t *Tx) ArchiveTransaction(transactionID uuid.UUID) (err error) {
 	timestamp := time.Now()
 	params := []any{
 		sql.Named("id", transactionID),
@@ -217,7 +262,7 @@ func (s *Store) archiveTransaction(tx *sql.Tx, transactionID uuid.UUID) (err err
 	}
 
 	var result sql.Result
-	if result, err = tx.Exec(archiveTransactionSQL, params...); err != nil {
+	if result, err = t.tx.Exec(archiveTransactionSQL, params...); err != nil {
 		return dbe(err)
 	}
 
@@ -229,21 +274,20 @@ func (s *Store) archiveTransaction(tx *sql.Tx, transactionID uuid.UUID) (err err
 }
 
 func (s *Store) UnarchiveTransaction(ctx context.Context, transactionID uuid.UUID) (err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
-	if err = s.unarchiveTransaction(tx, transactionID); err != nil {
+	if err = tx.UnarchiveTransaction(transactionID); err != nil {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
-func (s *Store) unarchiveTransaction(tx *sql.Tx, transactionID uuid.UUID) (err error) {
+func (t *Tx) UnarchiveTransaction(transactionID uuid.UUID) (err error) {
 	params := []any{
 		sql.Named("id", transactionID),
 		sql.Named("archived", false),
@@ -252,7 +296,7 @@ func (s *Store) unarchiveTransaction(tx *sql.Tx, transactionID uuid.UUID) (err e
 	}
 
 	var result sql.Result
-	if result, err = tx.Exec(archiveTransactionSQL, params...); err != nil {
+	if result, err = t.tx.Exec(archiveTransactionSQL, params...); err != nil {
 		return dbe(err)
 	}
 
@@ -266,32 +310,43 @@ func (s *Store) unarchiveTransaction(tx *sql.Tx, transactionID uuid.UUID) (err e
 const countTransactionsSQL = "SELECT count(id), status FROM transactions WHERE archived=:archived GROUP BY status"
 
 func (s *Store) CountTransactions(ctx context.Context) (counts *models.TransactionCounts, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
+
+	if counts, err = tx.CountTransactions(); err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return counts, nil
+}
+
+func (t *Tx) CountTransactions() (counts *models.TransactionCounts, err error) {
 
 	counts = &models.TransactionCounts{
 		Active:   make(map[string]int),
 		Archived: make(map[string]int),
 	}
 
-	if err = s.countTransactions(tx, counts, false); err != nil {
+	if err = t.countTransactions(counts, false); err != nil {
 		return nil, err
 	}
 
-	if err = s.countTransactions(tx, counts, true); err != nil {
+	if err = t.countTransactions(counts, true); err != nil {
 		return nil, err
 	}
 
-	tx.Commit()
 	return counts, nil
 }
 
-func (s *Store) countTransactions(tx *sql.Tx, counts *models.TransactionCounts, archived bool) (err error) {
+func (t *Tx) countTransactions(counts *models.TransactionCounts, archived bool) (err error) {
 	var rows *sql.Rows
-	if rows, err = tx.Query(countTransactionsSQL, sql.Named("archived", archived)); err != nil {
+	if rows, err = t.tx.Query(countTransactionsSQL, sql.Named("archived", archived)); err != nil {
 		return dbe(err)
 	}
 	defer rows.Close()
@@ -316,22 +371,28 @@ func (s *Store) countTransactions(tx *sql.Tx, counts *models.TransactionCounts, 
 const transactionStateSQL = "SELECT archived, status FROM transactions WHERE id=:id"
 
 func (s *Store) TransactionState(ctx context.Context, transactionID uuid.UUID) (archived bool, status enum.Status, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return archived, status, err
 	}
 	defer tx.Rollback()
 
-	var row *sql.Row
-	if row = tx.QueryRow(transactionStateSQL, sql.Named("id", transactionID)); err != nil {
-		return archived, status, dbe(err)
+	if archived, status, err = tx.TransactionState(transactionID); err != nil {
+		return archived, status, err
 	}
 
+	if err = tx.Commit(); err != nil {
+		return false, enum.StatusUnspecified, err
+	}
+
+	return archived, status, nil
+}
+
+func (t *Tx) TransactionState(transactionID uuid.UUID) (archived bool, status enum.Status, err error) {
+	row := t.tx.QueryRow(transactionStateSQL, sql.Named("id", transactionID))
 	if err = row.Scan(&archived, &status); err != nil {
 		return archived, status, dbe(err)
 	}
-
-	tx.Commit()
 	return archived, status, nil
 }
 
@@ -342,14 +403,25 @@ func (s *Store) TransactionState(ctx context.Context, transactionID uuid.UUID) (
 const listSecureEnvelopesSQL = "SELECT * FROM secure_envelopes WHERE envelope_id=:envelopeID ORDER BY timestamp DESC"
 
 func (s *Store) ListSecureEnvelopes(ctx context.Context, txID uuid.UUID, page *models.PageInfo) (out *models.SecureEnvelopePage, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
+	if out, err = tx.ListSecureEnvelopes(txID, page); err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (t *Tx) ListSecureEnvelopes(txID uuid.UUID, page *models.PageInfo) (out *models.SecureEnvelopePage, err error) {
 	var transaction *models.Transaction
-	if transaction, err = s.retrieveTransaction(tx, txID); err != nil {
+	if transaction, err = t.retrieveTransaction(txID); err != nil {
 		return nil, err
 	}
 
@@ -360,7 +432,7 @@ func (s *Store) ListSecureEnvelopes(ctx context.Context, txID uuid.UUID, page *m
 	}
 
 	var rows *sql.Rows
-	if rows, err = tx.Query(listSecureEnvelopesSQL, sql.Named("envelopeID", txID)); err != nil {
+	if rows, err = t.tx.Query(listSecureEnvelopesSQL, sql.Named("envelopeID", txID)); err != nil {
 		return nil, dbe(err)
 	}
 	defer rows.Close()
@@ -378,14 +450,12 @@ func (s *Store) ListSecureEnvelopes(ctx context.Context, txID uuid.UUID, page *m
 	if errors.Is(rows.Err(), sql.ErrNoRows) {
 		return nil, dberr.ErrNotFound
 	}
-
-	tx.Commit()
 	return out, nil
 }
 
-func (s *Store) listSecureEnvelopes(tx *sql.Tx, transaction *models.Transaction) (err error) {
+func (t *Tx) associateSecureEnvelopes(transaction *models.Transaction) (err error) {
 	var rows *sql.Rows
-	if rows, err = tx.Query(listSecureEnvelopesSQL, sql.Named("envelopeID", transaction.ID)); err != nil {
+	if rows, err = t.tx.Query(listSecureEnvelopesSQL, sql.Named("envelopeID", transaction.ID)); err != nil {
 		return dbe(err)
 	}
 	defer rows.Close()
@@ -408,6 +478,20 @@ func (s *Store) listSecureEnvelopes(tx *sql.Tx, transaction *models.Transaction)
 const createSecureEnvelopeSQL = "INSERT INTO secure_envelopes (id, envelope_id, direction, remote, reply_to, is_error, encryption_key, hmac_secret, valid_hmac, timestamp, public_key, transfer_state, envelope, created, modified) VALUES (:id, :envelopeID, :direction, :remote, :replyTo, :isError, :encryptionKey, :hmacSecret, :validHMAC, :timestamp, :publicKey, :transferState, :envelope, :created, :modified)"
 
 func (s *Store) CreateSecureEnvelope(ctx context.Context, env *models.SecureEnvelope) (err error) {
+	var tx *Tx
+	if tx, err = s.BeginTx(ctx, nil); err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err = tx.CreateSecureEnvelope(env); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (t *Tx) CreateSecureEnvelope(env *models.SecureEnvelope) (err error) {
 	if !env.ID.IsZero() {
 		return dberr.ErrNoIDOnCreate
 	}
@@ -421,40 +505,57 @@ func (s *Store) CreateSecureEnvelope(ctx context.Context, env *models.SecureEnve
 	env.Created = time.Now()
 	env.Modified = env.Created
 
-	var tx *sql.Tx
-	if tx, err = s.BeginTx(ctx, nil); err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	if _, err = tx.Exec(createSecureEnvelopeSQL, env.Params()...); err != nil {
+	if _, err = t.tx.Exec(createSecureEnvelopeSQL, env.Params()...); err != nil {
 		return dbe(err)
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 const retrieveSecureEnvelopeSQL = "SELECT * FROM secure_envelopes WHERE id=:envID and envelope_id=:txID"
 
 func (s *Store) RetrieveSecureEnvelope(ctx context.Context, txID uuid.UUID, envID ulid.ULID) (env *models.SecureEnvelope, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	env = &models.SecureEnvelope{}
-	if err = env.Scan(tx.QueryRow(retrieveSecureEnvelopeSQL, sql.Named("envID", envID), sql.Named("txID", txID))); err != nil {
-		return nil, dbe(err)
+	if env, err = tx.RetrieveSecureEnvelope(txID, envID); err != nil {
+		return nil, err
 	}
 
-	tx.Commit()
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+func (t *Tx) RetrieveSecureEnvelope(txID uuid.UUID, envID ulid.ULID) (env *models.SecureEnvelope, err error) {
+	env = &models.SecureEnvelope{}
+	if err = env.Scan(t.tx.QueryRow(retrieveSecureEnvelopeSQL, sql.Named("envID", envID), sql.Named("txID", txID))); err != nil {
+		return nil, dbe(err)
+	}
 	return env, nil
 }
 
 const updateSecureEnvelopeSQL = "UPDATE secure_envelopes SET direction=:direction, remote=:remote, reply_to=:replyTo, is_error=:is_error, encryption_key=:encryptionKey, hmac_secret=:hmacSecret, valid_hmac=:validHMAC, timestamp=:timestamp, public_key=:publicKey, transfer_state=:transferState, envelope=:envelope, modified=:modified WHERE id=:id and envelope_id=:envelopeID"
 
 func (s *Store) UpdateSecureEnvelope(ctx context.Context, env *models.SecureEnvelope) (err error) {
+	var tx *Tx
+	if tx, err = s.BeginTx(ctx, nil); err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err = tx.UpdateSecureEnvelope(env); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (t *Tx) UpdateSecureEnvelope(env *models.SecureEnvelope) (err error) {
 	// Basic validation
 	if env.ID.IsZero() {
 		return dberr.ErrMissingID
@@ -464,16 +565,10 @@ func (s *Store) UpdateSecureEnvelope(ctx context.Context, env *models.SecureEnve
 		return dberr.ErrMissingReference
 	}
 
-	var tx *sql.Tx
-	if tx, err = s.BeginTx(ctx, nil); err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
 	env.Modified = time.Now()
 
 	var result sql.Result
-	if result, err = tx.Exec(updateSecureEnvelopeSQL, env.Params()...); err != nil {
+	if result, err = t.tx.Exec(updateSecureEnvelopeSQL, env.Params()...); err != nil {
 		return dbe(err)
 	}
 
@@ -481,20 +576,28 @@ func (s *Store) UpdateSecureEnvelope(ctx context.Context, env *models.SecureEnve
 		return dberr.ErrNotFound
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 const deleteSecureEnvelopeSQL = "DELETE FROM secure_envelopes WHERE id=:envID AND envelope_id=:txID"
 
 func (s *Store) DeleteSecureEnvelope(ctx context.Context, txID uuid.UUID, envID ulid.ULID) (err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
+	if err = tx.DeleteSecureEnvelope(txID, envID); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (t *Tx) DeleteSecureEnvelope(txID uuid.UUID, envID ulid.ULID) (err error) {
 	var result sql.Result
-	if result, err = tx.Exec(deleteSecureEnvelopeSQL, sql.Named("txID", txID), sql.Named("envID", envID)); err != nil {
+	if result, err = t.tx.Exec(deleteSecureEnvelopeSQL, sql.Named("txID", txID), sql.Named("envID", envID)); err != nil {
 		return dbe(err)
 	}
 
@@ -502,7 +605,7 @@ func (s *Store) DeleteSecureEnvelope(ctx context.Context, txID uuid.UUID, envID 
 		return dberr.ErrNotFound
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 //===========================================================================
@@ -515,19 +618,30 @@ const (
 )
 
 func (s *Store) LatestSecureEnvelope(ctx context.Context, envelopeID uuid.UUID, direction enum.Direction) (env *models.SecureEnvelope, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
+	if env, err = tx.LatestSecureEnvelope(envelopeID, direction); err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+func (t *Tx) LatestSecureEnvelope(envelopeID uuid.UUID, direction enum.Direction) (env *models.SecureEnvelope, err error) {
 	var result *sql.Row
 	if direction == enum.DirectionUnknown || direction == enum.DirectionAny {
 		// Get the latest secure envelope regardless of the direction
-		result = tx.QueryRow(latestSecEnvSQL, sql.Named("envelopeID", envelopeID))
+		result = t.tx.QueryRow(latestSecEnvSQL, sql.Named("envelopeID", envelopeID))
 	} else {
 		// Specify the direction to get the latest envelope for
-		result = tx.QueryRow(latestSecEnvByDirectionSQL, sql.Named("envelopeID", envelopeID), sql.Named("direction", direction))
+		result = t.tx.QueryRow(latestSecEnvByDirectionSQL, sql.Named("envelopeID", envelopeID), sql.Named("direction", direction))
 	}
 
 	env = &models.SecureEnvelope{}
@@ -535,7 +649,6 @@ func (s *Store) LatestSecureEnvelope(ctx context.Context, envelopeID uuid.UUID, 
 		return nil, dbe(err)
 	}
 
-	tx.Commit()
 	return env, nil
 }
 
@@ -545,27 +658,36 @@ const (
 )
 
 func (s *Store) LatestPayloadEnvelope(ctx context.Context, envelopeID uuid.UUID, direction enum.Direction) (env *models.SecureEnvelope, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
+	if env, err = tx.LatestPayloadEnvelope(envelopeID, direction); err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+func (t *Tx) LatestPayloadEnvelope(envelopeID uuid.UUID, direction enum.Direction) (env *models.SecureEnvelope, err error) {
 	var result *sql.Row
 	if direction == enum.DirectionUnknown || direction == enum.DirectionAny {
 		// Get the latest secure envelope regardless of the direction
-		result = tx.QueryRow(latestPayload, sql.Named("envelopeID", envelopeID))
+		result = t.tx.QueryRow(latestPayload, sql.Named("envelopeID", envelopeID))
 	} else {
 		// Specify the direction to get the latest envelope for
-		result = tx.QueryRow(latestPayloadByDirectionSQL, sql.Named("envelopeID", envelopeID), sql.Named("direction", direction))
+		result = t.tx.QueryRow(latestPayloadByDirectionSQL, sql.Named("envelopeID", envelopeID), sql.Named("direction", direction))
 	}
 
 	env = &models.SecureEnvelope{}
 	if err = env.Scan(result); err != nil {
 		return nil, dbe(err)
 	}
-
-	tx.Commit()
 	return env, nil
 }
 
@@ -578,7 +700,7 @@ const (
 )
 
 func (s *Store) PrepareTransaction(ctx context.Context, envelopeID uuid.UUID) (_ models.PreparedTransaction, err error) {
-	var tx *sql.Tx
+	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
 		return nil, err
 	}
@@ -616,7 +738,7 @@ func (s *Store) PrepareTransaction(ctx context.Context, envelopeID uuid.UUID) (_
 }
 
 type PreparedTransaction struct {
-	tx         *sql.Tx
+	tx         *Tx
 	envelopeID uuid.UUID
 	created    bool
 }
@@ -725,11 +847,11 @@ func (p *PreparedTransaction) AddCounterparty(in *models.Counterparty) (err erro
 }
 
 func (p *PreparedTransaction) UpdateCounterparty(in *models.Counterparty) (err error) {
-	return updateCounterparty(p.tx, in)
+	return p.tx.UpdateCounterparty(in)
 }
 
 func (p *PreparedTransaction) LookupCounterparty(field, value string) (*models.Counterparty, error) {
-	return lookupCounterparty(p.tx, field, value)
+	return p.tx.LookupCounterparty(field, value)
 }
 
 func (p *PreparedTransaction) AddEnvelope(in *models.SecureEnvelope) (err error) {
@@ -753,15 +875,15 @@ func (p *PreparedTransaction) AddEnvelope(in *models.SecureEnvelope) (err error)
 }
 
 func (p *PreparedTransaction) CreateSunrise(in *models.Sunrise) error {
-	return createSunrise(p.tx, in)
+	return p.tx.CreateSunrise(in)
 }
 
 func (p *PreparedTransaction) UpdateSunrise(in *models.Sunrise) error {
-	return updateSunrise(p.tx, in)
+	return p.tx.UpdateSunrise(in)
 }
 
 func (p *PreparedTransaction) UpdateSunriseStatus(txID uuid.UUID, status enum.Status) error {
-	return updateSunriseStatus(p.tx, txID, status)
+	return p.tx.UpdateSunriseStatus(txID, status)
 }
 
 func (p *PreparedTransaction) Rollback() error {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -45,7 +45,7 @@ func Open(databaseURL string) (s Store, err error) {
 // interface is added to the Store interface, it should be added to the txn.Tx interface
 // as well (to ensure the Txn has the same methods as the Store).
 type Store interface {
-	Begin(context.Context, *sql.TxOptions) (txn.Tx, error)
+	Begin(context.Context, *sql.TxOptions) (txn.Txn, error)
 
 	io.Closer
 	TransactionStore
@@ -78,8 +78,8 @@ var (
 
 // All Tx implementations must implement the Tx interface
 var (
-	_ txn.Tx = &sqlite.Tx{}
-	_ txn.Tx = &mock.Tx{}
+	_ txn.Txn = &sqlite.Tx{}
+	_ txn.Txn = &mock.Tx{}
 )
 
 // The Stats interface exposes database statistics if it is available from the backend.

--- a/pkg/store/txn/txn.go
+++ b/pkg/store/txn/txn.go
@@ -1,0 +1,17 @@
+/*
+Unfortunately, to prevent import cycle, we have to put the transaction interface in a
+subpackage of store so that store and other packages can import it. This means that
+whenver a new database interface is created, we have to also implement the parallel
+transaction interface as well.
+*/
+package txn
+
+// Tx is a storage interface for executing multiple operations against the database so
+// that if all operations succeed, the transaction can be committed. If any operation
+// fails, the transaction can be rolled back to ensure that the database is not left in
+// an inconsistent state. Tx should have similar methods to the Store interface, but
+// without requiring the context (this is passed to the transaction when it is created).
+type Tx interface {
+	Rollback() error
+	Commit() error
+}

--- a/pkg/store/txn/txn.go
+++ b/pkg/store/txn/txn.go
@@ -6,12 +6,152 @@ transaction interface as well.
 */
 package txn
 
-// Tx is a storage interface for executing multiple operations against the database so
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/trisacrypto/envoy/pkg/enum"
+	"github.com/trisacrypto/envoy/pkg/store/models"
+	"go.rtnl.ai/ulid"
+)
+
+// Txn is a storage interface for executing multiple operations against the database so
 // that if all operations succeed, the transaction can be committed. If any operation
 // fails, the transaction can be rolled back to ensure that the database is not left in
-// an inconsistent state. Tx should have similar methods to the Store interface, but
+// an inconsistent state. Txn should have similar methods to the Store interface, but
 // without requiring the context (this is passed to the transaction when it is created).
-type Tx interface {
+type Txn interface {
 	Rollback() error
 	Commit() error
+
+	TransactionTxn
+	AccountTxn
+	CounterpartyTxn
+	ContactTxn
+	SunriseTxn
+	UserTxn
+	APIKeyTxn
+	ResetPasswordLinkTxn
+}
+
+// TransactionTxn stores some lightweight information about specific transactions
+// stored in the database (most of which is not sensitive and is used for indexing).
+// It also maintains an association with all secure envelopes sent and received as
+// part of completing a travel rule exchange for the transaction.
+type TransactionTxn interface {
+	SecureEnvelopeTxn
+	ListTransactions(*models.TransactionPageInfo) (*models.TransactionPage, error)
+	CreateTransaction(*models.Transaction) error
+	RetrieveTransaction(uuid.UUID) (*models.Transaction, error)
+	UpdateTransaction(*models.Transaction) error
+	DeleteTransaction(uuid.UUID) error
+	ArchiveTransaction(uuid.UUID) error
+	UnarchiveTransaction(uuid.UUID) error
+	CountTransactions() (*models.TransactionCounts, error)
+	TransactionState(uuid.UUID) (archived bool, status enum.Status, err error)
+}
+
+// SecureEnvelopes are associated with individual transactions.
+type SecureEnvelopeTxn interface {
+	ListSecureEnvelopes(txID uuid.UUID, page *models.PageInfo) (*models.SecureEnvelopePage, error)
+	CreateSecureEnvelope(*models.SecureEnvelope) error
+	RetrieveSecureEnvelope(txID uuid.UUID, envID ulid.ULID) (*models.SecureEnvelope, error)
+	UpdateSecureEnvelope(*models.SecureEnvelope) error
+	DeleteSecureEnvelope(txID uuid.UUID, envID ulid.ULID) error
+	LatestSecureEnvelope(txID uuid.UUID, direction enum.Direction) (*models.SecureEnvelope, error)
+	LatestPayloadEnvelope(txID uuid.UUID, direction enum.Direction) (*models.SecureEnvelope, error)
+}
+
+// AccountTxn provides CRUD interactions with Account models.
+type AccountTxn interface {
+	CryptoAddressTxn
+	ListAccounts(page *models.PageInfo) (*models.AccountsPage, error)
+	CreateAccount(*models.Account) error
+	LookupAccount(cryptoAddress string) (*models.Account, error)
+	RetrieveAccount(id ulid.ULID) (*models.Account, error)
+	UpdateAccount(*models.Account) error
+	DeleteAccount(id ulid.ULID) error
+	ListAccountTransactions(accountID ulid.ULID, page *models.TransactionPageInfo) (*models.TransactionPage, error)
+}
+
+// CryptoAddressTxn provides CRUD interactions with CryptoAddress models and their
+// associated Account model.
+type CryptoAddressTxn interface {
+	ListCryptoAddresses(accountID ulid.ULID, page *models.PageInfo) (*models.CryptoAddressPage, error)
+	CreateCryptoAddress(*models.CryptoAddress) error
+	RetrieveCryptoAddress(accountID, cryptoAddressID ulid.ULID) (*models.CryptoAddress, error)
+	UpdateCryptoAddress(*models.CryptoAddress) error
+	DeleteCryptoAddress(accountID, cryptoAddressID ulid.ULID) error
+}
+
+// Counterparty store provides CRUD interactions with Counterparty models.
+type CounterpartyTxn interface {
+	SearchCounterparties(query *models.SearchQuery) (*models.CounterpartyPage, error)
+	ListCounterparties(page *models.CounterpartyPageInfo) (*models.CounterpartyPage, error)
+	ListCounterpartySourceInfo(source enum.Source) ([]*models.CounterpartySourceInfo, error)
+	CreateCounterparty(*models.Counterparty) error
+	RetrieveCounterparty(counterpartyID ulid.ULID) (*models.Counterparty, error)
+	LookupCounterparty(field, value string) (*models.Counterparty, error)
+	UpdateCounterparty(*models.Counterparty) error
+	DeleteCounterparty(counterpartyID ulid.ULID) error
+}
+
+type ContactTxn interface {
+	ListContacts(counterparty any, page *models.PageInfo) (*models.ContactsPage, error)
+	CreateContact(*models.Contact) error
+	RetrieveContact(contactID, counterpartyID any) (*models.Contact, error)
+	UpdateContact(*models.Contact) error
+	DeleteContact(contactID, counterpartyID any) error
+}
+
+// Sunrise store manages both contacts and counterparties.
+type SunriseTxn interface {
+	ListSunrise(*models.PageInfo) (*models.SunrisePage, error)
+	CreateSunrise(*models.Sunrise) error
+	RetrieveSunrise(ulid.ULID) (*models.Sunrise, error)
+	UpdateSunrise(*models.Sunrise) error
+	UpdateSunriseStatus(uuid.UUID, enum.Status) error
+	DeleteSunrise(ulid.ULID) error
+	GetOrCreateSunriseCounterparty(email, name string) (*models.Counterparty, error)
+}
+
+type UserTxn interface {
+	ListUsers(page *models.UserPageInfo) (*models.UserPage, error)
+	CreateUser(*models.User) error
+	RetrieveUser(emailOrUserID any) (*models.User, error)
+	UpdateUser(*models.User) error
+	SetUserPassword(userID ulid.ULID, password string) error
+	SetUserLastLogin(userID ulid.ULID, lastLogin time.Time) error
+	DeleteUser(userID ulid.ULID) error
+	LookupRole(role string) (*models.Role, error)
+}
+
+type APIKeyTxn interface {
+	ListAPIKeys(*models.PageInfo) (*models.APIKeyPage, error)
+	CreateAPIKey(*models.APIKey) error
+	RetrieveAPIKey(clientIDOrKeyID any) (*models.APIKey, error)
+	UpdateAPIKey(*models.APIKey) error
+	DeleteAPIKey(keyID ulid.ULID) error
+}
+
+type ResetPasswordLinkTxn interface {
+	ListResetPasswordLinks(*models.PageInfo) (*models.ResetPasswordLinkPage, error)
+	CreateResetPasswordLink(*models.ResetPasswordLink) error
+	RetrieveResetPasswordLink(ulid.ULID) (*models.ResetPasswordLink, error)
+	UpdateResetPasswordLink(*models.ResetPasswordLink) error
+	DeleteResetPasswordLink(ulid.ULID) error
+}
+
+// Methods required for managing Daybreak records in the database. This interface allows
+// us to have a single transaction open for a daybreak operation so that with respect
+// to a single counterparty we completely create the record or rollback on failure.
+//
+// NOTE: this is not part of the Txn interface since it is not required for the
+// server to function but is useful for Daybreak-specific operations.
+type DaybreakTxn interface {
+	ListDaybreak(ctx context.Context) (map[string]*models.CounterpartySourceInfo, error)
+	CreateDaybreak(counterparty *models.Counterparty) error
+	UpdateDaybreak(counterparty *models.Counterparty) error
+	DeleteDaybreak(counterpartyID ulid.ULID, ignoreTxns bool) error
 }


### PR DESCRIPTION
### Scope of changes

Adds a `txn.Tx` interface that allows you to access the store in the same way as the `Store` interface but using a db transaction that can be rolled back or committed. This should replace `PreparedTransaction`, make `Daybreak` operations a bit easier to write, and generally make the development experience with the database easier. 

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

This PR will be merged without review. @chris-okuda feel free to take a look and add comments though!

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation