### PR TITLE
Fix national identifier in customer account bug

### DIFF
--- a/pkg/web/static/js/accounts/edit.js
+++ b/pkg/web/static/js/accounts/edit.js
@@ -98,10 +98,6 @@ document.body.addEventListener("htmx:configRequest", function(e) {
           }
 
           obj = obj.nameIdentifier[idx];
-
-          if (key === "nationalIdentifier" && value !== "") {
-            hasNationalIdentifier = true;
-          }
         }
 
       } else if (key.startsWith("geographicAddress_")) {
@@ -128,6 +124,9 @@ document.body.addEventListener("htmx:configRequest", function(e) {
         key = key.replace("nationalIdentification_", "");
         obj = obj.nationalIdentification;
 
+        if (key === "nationalIdentifier" && value !== "") {
+          hasNationalIdentifier = true;
+        }
       } else if (key.startsWith("dateAndPlaceOfBirth_")) {
         key = key.replace("dateAndPlaceOfBirth_", "");
         obj = obj.dateAndPlaceOfBirth;


### PR DESCRIPTION
### Scope of changes

Fixes a bug where the national identifier was not being sent with the payload to update the customer account IVMS101. The javascript had a failed check that was always setting the national identifier to null.

Fixes SC-30573

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Forgive Ben for being such a bad coder.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


