### PR TITLE
Ensure the 'Counterparty.Website' field has a protocol attached

### DIFF
--- a/cmd/envoy/main.go
+++ b/cmd/envoy/main.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -590,6 +591,19 @@ func daybreakImport(c *cli.Context) (err error) {
 		if !modelCounterparty.RegisteredDirectory.Valid || modelCounterparty.RegisteredDirectory.String != "daybreak.rotational.io" {
 			log.Warn().Str("directory_id", apiCounterparty.DirectoryID).Str("name", apiCounterparty.Name).Msg("registered directory must be 'daybreak.rotational.io' to import")
 			continue
+		}
+
+		// ensure the website has a protocol (default to `https://`)
+		if modelCounterparty.Website.Valid {
+			if !strings.Contains(modelCounterparty.Website.String, "://") {
+				modelCounterparty.Website.String = fmt.Sprintf("https://%s", modelCounterparty.Website.String)
+			}
+			parsed, err := url.Parse(modelCounterparty.Website.String)
+			if err != nil {
+				log.Warn().Str("directory_id", apiCounterparty.DirectoryID).Str("name", apiCounterparty.Name).Msg("there was an error parsing the website string")
+				continue
+			}
+			modelCounterparty.Website.String = parsed.String()
 		}
 
 		// Set the contacts onto the model to be added to the database.

--- a/pkg/web/counterparties_test.go
+++ b/pkg/web/counterparties_test.go
@@ -1,0 +1,3 @@
+package web_test
+
+//TODO: test Server.CreateCounterparty() and Server.UpdateCounterparty() with websites that have protocols and some without protocols


### PR DESCRIPTION
### Scope of changes

Add parsing/checks to ensure a protocol schema like `https://` is on every counterparty website.

TODO: need to add a test for this, too.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Nothing special.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


