### PR TITLE
Add SetAPIKeyLastSeen store/txn update functions

### DIFF
--- a/pkg/store/mock/store.go
+++ b/pkg/store/mock/store.go
@@ -91,6 +91,7 @@ type Store struct {
 	OnCreateAPIKey                   func(ctx context.Context, in *models.APIKey, log *models.ComplianceAuditLog) error
 	OnRetrieveAPIKey                 func(ctx context.Context, clientIDOrKeyID any) (*models.APIKey, error)
 	OnUpdateAPIKey                   func(ctx context.Context, in *models.APIKey, log *models.ComplianceAuditLog) error
+	OnSetAPIKeyLastSeen              func(ctx context.Context, keyID ulid.ULID, lastSeen time.Time) error
 	OnDeleteAPIKey                   func(ctx context.Context, keyID ulid.ULID, log *models.ComplianceAuditLog) error
 	OnListResetPasswordLinks         func(ctx context.Context, page *models.PageInfo) (*models.ResetPasswordLinkPage, error)
 	OnCreateResetPasswordLink        func(ctx context.Context, link *models.ResetPasswordLink) error
@@ -789,6 +790,15 @@ func (s *Store) UpdateAPIKey(ctx context.Context, in *models.APIKey, log *models
 		return s.OnUpdateAPIKey(ctx, in, log)
 	}
 	panic("UpdateAPIKey callback not set")
+}
+
+// Calls the callback previously set with `s.OnSetAPIKeyLastSeen = ...`
+func (s *Store) SetAPIKeyLastSeen(ctx context.Context, keyID ulid.ULID, lastSeen time.Time) error {
+	s.calls["SetAPIKeyLastSeen"]++
+	if s.OnSetAPIKeyLastSeen != nil {
+		return s.OnSetAPIKeyLastSeen(ctx, keyID, lastSeen)
+	}
+	panic("SetAPIKeyLastSeen callback not set")
 }
 
 // Calls the callback previously set with `s.OnDeleteAPIKey = ...`

--- a/pkg/store/mock/txn.go
+++ b/pkg/store/mock/txn.go
@@ -90,6 +90,7 @@ type Tx struct {
 	OnCreateAPIKey                   func(in *models.APIKey, log *models.ComplianceAuditLog) error
 	OnRetrieveAPIKey                 func(clientIDOrKeyID any) (*models.APIKey, error)
 	OnUpdateAPIKey                   func(in *models.APIKey, log *models.ComplianceAuditLog) error
+	OnSetAPIKeyLastSeen              func(keyID ulid.ULID, lastSeen time.Time) error
 	OnDeleteAPIKey                   func(keyID ulid.ULID, log *models.ComplianceAuditLog) error
 	OnListResetPasswordLinks         func(page *models.PageInfo) (*models.ResetPasswordLinkPage, error)
 	OnCreateResetPasswordLink        func(in *models.ResetPasswordLink) error
@@ -985,6 +986,18 @@ func (tx *Tx) UpdateAPIKey(in *models.APIKey, log *models.ComplianceAuditLog) er
 		return tx.OnUpdateAPIKey(in, log)
 	}
 	panic("UpdateAPIKey callback not set")
+}
+
+// Calls the callback previously set with `OnSetAPIKeyLastSeen()`
+func (tx *Tx) SetAPIKeyLastSeen(keyID ulid.ULID, lastSeen time.Time) error {
+	if err := tx.check(true); err != nil {
+		return err
+	}
+
+	if tx.OnSetAPIKeyLastSeen != nil {
+		return tx.OnSetAPIKeyLastSeen(keyID, lastSeen)
+	}
+	panic("SetAPIKeyLastSeen callback not set")
 }
 
 // Calls the callback previously set with "OnDeleteAPIKey()".

--- a/pkg/store/sqlite/auth.go
+++ b/pkg/store/sqlite/auth.go
@@ -655,7 +655,7 @@ func (t *Tx) UpdateAPIKey(key *models.APIKey, auditLog *models.ComplianceAuditLo
 
 const setAPIKeyLastSeenSQL = "UPDATE api_keys SET last_seen=:lastSeen, modified=:modified WHERE id=:id"
 
-func (s *Store) SetAPIKeyLastSeen(ctx context.Context, userID ulid.ULID, lastLogin time.Time) (err error) {
+func (s *Store) SetAPIKeyLastSeen(ctx context.Context, keyID ulid.ULID, lastSeen time.Time) (err error) {
 	//NOTE: this type of update does not require an audit log entry
 	var tx *Tx
 	if tx, err = s.BeginTx(ctx, nil); err != nil {
@@ -663,18 +663,18 @@ func (s *Store) SetAPIKeyLastSeen(ctx context.Context, userID ulid.ULID, lastLog
 	}
 	defer tx.Rollback()
 
-	if err = tx.SetAPIKeyLastSeen(userID, lastLogin); err != nil {
+	if err = tx.SetAPIKeyLastSeen(keyID, lastSeen); err != nil {
 		return err
 	}
 
 	return tx.Commit()
 }
 
-func (t *Tx) SetAPIKeyLastSeen(userID ulid.ULID, lastLogin time.Time) (err error) {
+func (t *Tx) SetAPIKeyLastSeen(keyID ulid.ULID, lastSeen time.Time) (err error) {
 	//NOTE: this type of update does not require an audit log entry
 	params := []any{
-		sql.Named("id", userID),
-		sql.Named("lastSeen", sql.NullTime{Time: lastLogin, Valid: !lastLogin.IsZero()}),
+		sql.Named("id", keyID),
+		sql.Named("lastSeen", sql.NullTime{Time: lastSeen, Valid: !lastSeen.IsZero()}),
 		sql.Named("modified", time.Now()),
 	}
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -194,6 +194,8 @@ type APIKeyStore interface {
 	CreateAPIKey(context.Context, *models.APIKey, *models.ComplianceAuditLog) error
 	RetrieveAPIKey(ctx context.Context, clientIDOrKeyID any) (*models.APIKey, error)
 	UpdateAPIKey(context.Context, *models.APIKey, *models.ComplianceAuditLog) error
+	// NOTE: last seen time update does not require an audit log entry:
+	SetAPIKeyLastSeen(ctx context.Context, keyID ulid.ULID, lastSeen time.Time) error
 	DeleteAPIKey(ctx context.Context, keyID ulid.ULID, auditLog *models.ComplianceAuditLog) error
 }
 

--- a/pkg/store/txn/txn.go
+++ b/pkg/store/txn/txn.go
@@ -138,6 +138,8 @@ type APIKeyTxn interface {
 	CreateAPIKey(*models.APIKey, *models.ComplianceAuditLog) error
 	RetrieveAPIKey(clientIDOrKeyID any) (*models.APIKey, error)
 	UpdateAPIKey(*models.APIKey, *models.ComplianceAuditLog) error
+	// NOTE: last seen time update does not require an audit log entry:
+	SetAPIKeyLastSeen(keyID ulid.ULID, lastSeen time.Time) error
 	DeleteAPIKey(keyID ulid.ULID, auditLog *models.ComplianceAuditLog) error
 }
 

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -172,10 +172,7 @@ func (s *Server) Authenticate(c *gin.Context) {
 	}
 
 	// Update api key last seen timestamp
-	apikey.LastSeen = sql.NullTime{Valid: true, Time: time.Now()}
-	if err = s.store.UpdateAPIKey(ctx, apikey, &models.ComplianceAuditLog{
-		ChangeNotes: sql.NullString{Valid: true, String: "Server.Authenticate()"},
-	}); err != nil {
+	if err = s.store.SetAPIKeyLastSeen(ctx, apikey.ID, time.Now()); err != nil {
 		log := logger.Tracing(ctx)
 		log.Warn().Err(err).Msg("unable to update api key last seen timestamp")
 
@@ -345,10 +342,7 @@ func (s *Server) reauthenticateAPIKey(c *gin.Context, keyID ulid.ULID) (_ *auth.
 		return nil, err
 	}
 
-	apikey.LastSeen = sql.NullTime{Valid: true, Time: time.Now()}
-	if err = s.store.UpdateAPIKey(ctx, apikey, &models.ComplianceAuditLog{
-		ChangeNotes: sql.NullString{Valid: true, String: "Server.requthenticateUser()"},
-	}); err != nil {
+	if err = s.store.SetAPIKeyLastSeen(ctx, apikey.ID, time.Now()); err != nil {
 		log := logger.Tracing(ctx)
 		log.Warn().Err(err).Msg("unable to update api key last seen timestamp")
 


### PR DESCRIPTION
### Scope of changes

**Problem:** When authenticating or reauthenticating with an API key, there is some missing contextual information necessary to create an audit log, so the audit logs cannot be created and the API key will fail to be authenticated. 

**Solution:** It is not necessary for an audit log to be created for a user when they change their password or login, so the same should apply to API keys. This adds `SetAPIKeyLastSeen` to the store and txn which only sets the timestamps on the API key when the key is authenticated or reauthenticated, and does not require an audit log to be created.

### Type of change

- [x] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Nothing special, just check it out.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


